### PR TITLE
bring persistence in request cache

### DIFF
--- a/src/media/js/cache.js
+++ b/src/media/js/cache.js
@@ -42,13 +42,55 @@ define('cache', ['log', 'rewriters'], function(log, rewriters) {
         }
     }
 
+    var persistentCachePrefix = 'cache.persist::';
+    var persistent = {
+        // This uses localStorage for persistent storage of cache entries.
+        get: function(key) {
+            if (has(key)) {
+                return get(key);
+            } else if (key in storageKeys) {
+                var val = storage.getItem(persistentCachePrefix + key);
+                set(key, val);
+                return val;
+            }
+        },
+        set: function(key, val) {
+            storage.setItem(persistentCachePrefix + key, val);
+            set(key, val);
+        },
+        bust: function(key) {
+            if (key in storageKeys) {
+                storage.removeItem(persistentCachePrefix + key);
+            }
+            bust(key);
+        },
+        has: function(key) {
+            return storage.getItem(persistentCachePrefix + key);
+        },
+        purge: function() {
+            for (var i = 0; i < storage.length; i++) {
+                var key = storage.key(i);
+                if (key.indexOf(persistentCachePrefix) === 0) {
+                    storage.removeItem(persistentCachePrefix + key);
+                    bust(key.replace(persistentCachePrefix, ''));
+                }
+            }
+        }
+    };
+
     function rewrite(matcher, worker, limit) {
         var count = 0;
         console.log('Attempting cache rewrite');
         for (var key in cache) {
             if (matcher(key)) {
                 console.log('Matched cache rewrite pattern for key ', key);
-                cache[key] = worker(cache[key], key);
+                var rewrittenValue = worker(cache[key], key);
+                cache[key] = rewrittenValue;
+
+                // Update persistent cache if the key exists there.
+                if (persistent.has(key)) {
+                    persistent.set(key, rewrittenValue);
+                }
                 if (limit && ++count >= limit) {
                     console.log('Cache rewrite limit hit, exiting');
                     return;
@@ -65,6 +107,8 @@ define('cache', ['log', 'rewriters'], function(log, rewriters) {
         purge: purge,
 
         attemptRewrite: rewrite,
-        raw: cache
+        raw: cache,
+
+        persist: persistent
     };
 });

--- a/src/media/js/requests.js
+++ b/src/media/js/requests.js
@@ -140,22 +140,23 @@ define('requests',
         return def;
     }
 
-    function get(url, nocache) {
+    function get(url, nocache, persistent) {
         if (cache.has(url) && !nocache) {
             console.log('GETing from cache', url);
             return defer.Deferred()
                         .resolve(cache.get(url))
                         .promise({__cached: true});
         }
-        return _get.apply(this, arguments);
+        return _get.apply(this, arguments, persistent);
     }
 
-    function _get(url, nocache) {
+    function _get(url, nocache, persistent) {
         console.log('GETing', url);
         return ajax('GET', url).done(function(data, xhr) {
             console.log('GOT', url);
             if (!nocache) {
                 cache.set(url, data);
+                if (persistent) cache.persist.set(url, data);
             }
         });
     }


### PR DESCRIPTION
Adds `cache.persist` which provides an interface similar to `cache` but stores data in localStorage.
