### PR TITLE
Allow app settings config from damperrc

### DIFF
--- a/bin/damper
+++ b/bin/damper
@@ -9,7 +9,7 @@ var stylus = require('stylus');
 var utils = require('../lib/utils.js');
 var info = require('../lib/info.js');
 
-var src_dir = require('../lib/info.js').src_dir();
+var src_dir = info.src_dir();
 
 process.title = 'damper';
 
@@ -36,8 +36,34 @@ info.check_version(
     }
 );
 
-var opts = utils.opts(process.argv.slice(2),
-                      {host: '0.0.0.0', port: '8675'});
+// Get the damperrc data.
+var rc_path = path.normalize(process.env.HOME + '/.damperrc');
+var rc_data = {};
+var app_rc_data;
+if (fs.existsSync(rc_path)) {
+    console.log('Loading .damperrc');
+    var home_path = src_dir.replace(process.env.HOME, '~');
+    rc_data = JSON.parse(fs.readFileSync(rc_path));
+    app_rc_data = rc_data[src_dir] ||
+                  rc_data[home_path] ||
+                  rc_data[path.dirname(src_dir)] ||
+                  rc_data[path.dirname(home_path)];
+
+    if (app_rc_data) {
+        console.log('Loaded app settings from .damperrc');
+    }
+}
+app_rc_data = app_rc_data || {};
+
+// Get the manifest data.
+var manifest_data = info.manifest(src_dir);
+
+var default_settings = {
+    host: manifest_data.host || app_rc_data.host || '0.0.0.0',
+    port: manifest_data.port || app_rc_data.port || '8675'
+};
+
+var opts = utils.opts(process.argv.slice(2), default_settings);
 
 // Here's the local server.
 http.createServer(function(request, response) {

--- a/lib/info.js
+++ b/lib/info.js
@@ -11,15 +11,26 @@ module.exports.src_dir = function() {
     }
 };
 
+// Return's the contents of the app's commonplace manifest.
+var manifest_ = module.exports.manifest = function(src_dir) {
+    var existing_manifest = path.resolve(src_dir, '.commonplace');
+    if (fs.existsSync(existing_manifest)) {
+        return JSON.parse(fs.readFileSync(existing_manifest));
+    } else {
+        return null;
+    }
+};
+
+// Returns the current commonplace installation's version.
 var version_ = module.exports.version = function() {
     var package_json = path.resolve(__dirname, '../package.json');
     return JSON.parse(fs.readFileSync(package_json)).version;
 };
 
 module.exports.check_version = function(src_dir, same, different, neither) {
-    var existing_manifest = path.resolve(src_dir, '.commonplace');
-    if (fs.existsSync(existing_manifest)) {
-        var version = JSON.parse(fs.readFileSync(existing_manifest)).version;
+    var manifest_data = manifest_(src_dir);
+    if (manifest_data) {
+        var version = manifest_data.version;
         var current_version = version_();
         if (version !== current_version && different) {
             different(version, current_version);


### PR DESCRIPTION
Running multiple instances of the damper is no longer a PITA. You have options!
1. Edit your app's `.commonplace` file with `"port"` and `"host"` fields
2. Edit `~/.damperrc` with a similar object

The `.damperrc` file should look like this:

``` js
{
  "/path/to/project": {"port": 8000},
  "~/myprojects/project": {"port": 8001}
}
```

The paths may point to the heart/src directory for the project or the repository's root (either works).

cc @cvan 
