### PR TITLE
keep track of url()s so we can appcache them

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -63,20 +63,42 @@ function concatCSS(src_dir, callback) {
     var css_pattern = /href="(\/media\/css\/.+\.styl\.css)"/g;
     var url_pattern = /url\(([^)]+)\)/g;
 
+    var css_urls = [];
+    var css_dir = path.resolve(src_dir, 'media/css');
+    var cssurls_fn = path.resolve(src_dir, 'media/cssurls.txt');
+    var has_origin = false;
+
     function fix_urls(data) {
         return data.replace(url_pattern, function(match, url, offset, string) {
             url = url.replace(/"|'/g, '');
-            if (url.search(/(https?|data):|\/\//) === 0) {
-                return ['url(', url, ')'].join('');
+            has_origin = false;
+
+            if (url.substring(0, 5) === 'data:') {
+                return 'url(' + url + ')';
             }
 
-            var timestamp = new Date().getTime();
-            if (url.indexOf('#') !== -1) {
-                var split = url.split('#');
-                return ['url(', split[0], '?', timestamp, '#', split[1], ')'].join('');
+            if (url.search(/(https?):|\/\//) === 0) {
+                // Do not cachebust https, http, and // urls.
+                has_origin = true;
             } else {
-                return ['url(', url, '?', timestamp, ')'].join('');
+                if (url[0] === '/') {
+                    has_origin = true;
+                }
+                url += '?' + new Date().getTime();
             }
+
+            if (css_urls.indexOf(url) === -1) {
+                if (has_origin) {
+                    css_urls.push(url);
+                } else {
+                    // Filename started with `../` or is a relative path.
+                    var absolute_path = path.join(css_dir, url);
+                    // Record the absolute URL, starting with `/media/`.
+                    css_urls.push('/' + path.relative(src_dir, absolute_path));
+                }
+            }
+
+            return 'url(' + url + ')';
         });
     }
 
@@ -105,7 +127,16 @@ function concatCSS(src_dir, callback) {
                     output[index] = fix_urls(data + '\n');
                 }
                 remaining--;
-                if (!remaining) callback(output.join('\n'));
+                if (!remaining) {
+                    fs.writeFile(cssurls_fn, css_urls.join('\n') + '\n', function(err) {
+                        if (err) {
+                            console.error('Error writing `cssurls.txt` to disk.');
+                            return;
+                        }
+                        console.log('Created ' + cssurls_fn);
+                    });
+                    callback(output.join('\n'));
+                }
             });
         });
     });

--- a/lib/commonplace.js
+++ b/lib/commonplace.js
@@ -523,7 +523,7 @@ function build_includes() {
                 var include_js = path.resolve(src_dir, 'media/js/include.js');
                 fs.writeFile(include_js, data, function(err) {
                     if (err) {
-                        console.warn('Error writing `include.js` to disk.');
+                        console.error('Error writing `include.js` to disk.');
                         return;
                     }
                     console.log('Created ' + include_js);
@@ -539,7 +539,7 @@ function build_includes() {
         var include_css = path.resolve(src_dir, 'media/css/include.css');
         fs.writeFile(include_css, data, function(err) {
             if (err) {
-                console.warn('Error writing `include.css` to disk.');
+                console.error('Error writing `include.css` to disk.');
                 return;
             }
             console.log('Created ' + include_css);


### PR DESCRIPTION
# Summary

It's easy to cache `splash.styl.css`, `include.css`, `include.js`, etc. But thinks like our fonts get cachebusted by commonplace's `includes` command after they've been stylus-ised.

If we're going to appcache things like our fonts we need to get the full URLs for this given build (BUILD_ID) and generate a dynamic `manifest.appcache` based on them.
# Usage

```
%% commonplace includes
Commonplace v0.1.15
Found different commonplace version.
Generated includes may not work as expected.
Created /opt/fireplace/hearth/media/cssurls.txt
Created /opt/fireplace/hearth/media/css/include.css
Created /opt/fireplace/hearth/media/js/include.js
```
# /opt/fireplace/hearth/media/cssurls.txt

```
/media/fonts/FeuraSans/FeuraSansWeb-Light.woff?1385153221789
/media/fonts/FeuraSans/FeuraSansWeb-Light.svg#FeuraSansWebLight?1385153221789
/media/fonts/FeuraSans/FeuraSansWeb-Regular.woff?1385153221789
/media/fonts/FeuraSans/FeuraSansWeb-Regular.svg#FeuraSansWebRegular?1385153221789
/media/fonts/FeuraSans/FeuraSansWeb-Medium.woff?1385153221789
/media/fonts/FeuraSans/FeuraSansWeb-Medium.svg#FeuraSansWebMedium?1385153221789
/media/fonts/FeuraSans/FeuraSansWeb-Bold.woff?1385153221789
/media/fonts/FeuraSans/FeuraSansWeb-Bold.svg#FeuraSansWebBold?1385153221789
/media/img/pretty/marketplace_logo.png?1385153221881
/media/img/btn_spinner.png?1385153221881
/media/img/icons/eggs/h1.gif?1385153221881
/media/img/icons/eggs/h4.gif?1385153221881
/media/img/pretty/rocket.png?1385153221881
/media/img/logos/footzilla.png?1385153221881
/media/img/logos/footzilla-2x.png?1385153221881
/media/img/icons/regions/worldwide.png?1385153221881
/media/img/icons/regions/br.png?1385153221881
/media/img/icons/regions/co.png?1385153221881
/media/img/icons/regions/es.png?1385153221881
/media/img/icons/regions/gr.png?1385153221881
/media/img/icons/regions/mx.png?1385153221881
/media/img/icons/regions/pl.png?1385153221881
/media/img/icons/regions/uk.png?1385153221881
/media/img/icons/regions/us.png?1385153221881
/media/img/icons/regions/ve.png?1385153221881
/media/img/icons/regions/rs.png?1385153221881
/media/img/icons/regions/me.png?1385153221881
/media/img/icons/regions/hu.png?1385153221881
/media/img/icons/regions/gr.png?1385153221881
/media/img/icons/regions/de.png?1385153221881
/media/img/icons/regions/ar.png?1385153221881
/media/img/icons/regions/uy.png?1385153221881
/media/img/icons/regions/pe.png?1385153221881
/media/img/icons/regions/cn.png?1385153221881
/media/img/btn_spinner_2x.png?1385153221881
/media/img/btn_spinner_alt_2x.png?1385153221881
/media/img/pretty/marketplace_logo.png?1385153221990
/media/img/pretty/search.svg?1385153221990
/media/img/pretty/close.svg?1385153221990
/media/img/pretty/settings_gear.svg?1385153221990
/media/img/pretty/back_arrow.svg?1385153221990
/media/img/pretty/back_arrow_active.svg?1385153221990
/media/img/btn_spinner.png?1385153221990
/media/img/pretty/settings_gear_active.svg?1385153221990
/media/img/pretty/list_view_active.svg?1385153221990
/media/img/pretty/screenshot_view.svg?1385153221990
/media/img/pretty/list_view.svg?1385153221990
/media/img/pretty/screenshot_view_active.svg?1385153221990
/media/img/pretty/cats-sprite.svg?1385153222076
/media/img/carriers/movistar.png?1385153222076
/media/img/carriers/deutsche_telekom.svg?1385153222076
/media/img/carriers/congstar.png?1385153222076
/media/img/carriers/telenor.svg?1385153222076
/media/img/carriers/claro.png?1385153222076
/media/img/carriers/vivo.png?1385153222076
/media/img/carriers/telenor.svg?1385153222076
/media/img/pretty/dropdown_mobile.svg?1385153222076
/media/img/pretty/tick.svg?1385153222076
/media/img/pretty/tick-white.svg?1385153222076
/media/img/pretty/dropdown.svg?1385153222076
/media/img/pretty/dropdown_active.svg?1385153222076
/media/img/icons/slider_arrow.png?1385153222183
/media/img/icons/slider_arrow-2x.png?1385153222183
/media/img/btn_spinner.png?1385153222331
/media/img/btn_spinner.png?1385153222331
/media/img/btn_spinner_18.png?1385153222331
/media/img/btn_spinner_alt_2x.png?1385153222331
/media/img/btn_spinner_18_2x.png?1385153222331
/media/img/pretty/collection_default.png?1385153222384
/media/img/icons/ratings/ESRB_e.png?1385153222453
/media/img/icons/ratings/ESRB_e10.png?1385153222453
/media/img/icons/ratings/ESRB_t.png?1385153222453
/media/img/icons/ratings/ESRB_m.png?1385153222453
/media/img/icons/ratings/ESRB_ao.png?1385153222453
/media/img/icons/ratings/USK_0.png?1385153222453
/media/img/icons/ratings/USK_6.png?1385153222453
/media/img/icons/ratings/USK_12.png?1385153222453
/media/img/icons/ratings/USK_16.png?1385153222453
/media/img/icons/ratings/USK_18.png?1385153222453
/media/img/icons/ratings/pegi_3.png?1385153222453
/media/img/icons/ratings/pegi_7.png?1385153222453
/media/img/icons/ratings/pegi_12.png?1385153222453
/media/img/icons/ratings/pegi_16.png?1385153222453
/media/img/icons/ratings/pegi_18.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_discrimination.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_drugs.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_fear.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_gambling.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_language.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_nudity.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_online.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_sex.png?1385153222453
/media/img/icons/ratings/descriptors/pegi_violence.png?1385153222453
/media/img/icons/ratings/interactives/ESRB_shares-info_small.png?1385153222453
/media/img/icons/ratings/interactives/ESRB_shares-location_small.png?1385153222453
/media/img/icons/ratings/interactives/ESRB_users-interact_small.png?1385153222453
/media/img/pretty/dropdown.svg?1385153222551
/media/img/pretty/dropdown_active.svg?1385153222551
/media/img/logos/firefox-256.png?1385153222635
/media/img/btn_spinner.png?1385153222691
/media/img/grain.png?1385153222776
/media/img/pretty/tick-white.svg?1385153222910
/media/img/icons/mac-applications.jpg?1385153222910
/media/img/icons/win-start.png?1385153222911
/media/img/pretty/stars_small.svg?1385153222998
/media/img/pretty/stars_large.svg?1385153222998
```
