### PR TITLE
Fixes nunjucks compat reference to undefined obj

### DIFF
--- a/src/media/js/lib/nunjucks.compat.js
+++ b/src/media/js/lib/nunjucks.compat.js
@@ -25,7 +25,7 @@ define('nunjucks.compat', ['nunjucks'], function(nunjucks) {
     var ARRAY_MEMBERS = {
         pop: function(index) {
             if (index === undefined) {
-                return obj.pop();
+                return this.pop();
             }
             if (index >= this.length || index < 0) {
                 throw new Error('KeyError');


### PR DESCRIPTION
This doesn't seem to be in use here, so no bug filed against it. But when used externally, this fails due to `obj` being undefined (it should be `this` instead).
