### PR TITLE
return explicit 'false' on _is_obj()

### DIFF
--- a/src/media/js/requests.js
+++ b/src/media/js/requests.js
@@ -15,7 +15,7 @@ define('requests',
     }
 
     function _is_obj(obj) {
-        return obj && obj.constructor === Object;
+        return typeof obj !== 'undefined' && obj.constructor === Object;
     }
 
     function _has_object_props(obj) {


### PR DESCRIPTION
Not a biggie since it's an internal function and 'undefined' is falsey but I found this while investigating another issue.

![fixobj](https://f.cloud.github.com/assets/391260/2374391/7046b1c8-a85f-11e3-9db0-ca9046f22396.png)
