### PR TITLE
Enhanced defer block events

### DIFF
--- a/src/media/js/builder.js
+++ b/src/media/js/builder.js
@@ -38,10 +38,12 @@ define('builder',
         parent.removeChild(to_replace);
     }
 
-    function fire(el, event_name) {
-        var args = Array.prototype.slice.call(arguments, 2);
-        var e = document.createEvent('Event');
-        e.initEvent.apply(e, [event_name, true, false].concat(args));
+    function fire(el, event_name, data) {
+        var e = new CustomEvent(event_name, {
+            bubbles: true,
+            cancelable: false,
+            detail: data
+        });
         el.dispatchEvent(e);
         return e;
     }
@@ -89,8 +91,11 @@ define('builder',
             }, false);
         }
 
-        function trigger_fragment_loaded(id) {
-            fire(page, 'fragment_loaded', id || null);
+        function trigger_fragment_loaded(data) {
+            fire(page, 'fragment_loaded', data);
+        }
+        function trigger_fragment_load_failed(data) {
+            fire(page, 'fragment_load_failed', data);
         }
 
         // This pretends to be the nunjucks extension that does the magic.
@@ -208,7 +213,7 @@ define('builder',
                             make_paginatable(injector, el, signature.paginate);
                         }
 
-                        trigger_fragment_loaded(signature.id || null);
+                        trigger_fragment_loaded({context: context, signature: signature});
 
                     }).fail(function(xhr, text, code, response) {
                         if (!replace) {
@@ -220,6 +225,7 @@ define('builder',
                             context.ctx.error = code;
                             el.innerHTML = except ? except() : error_template;
                         }
+                        trigger_fragment_load_failed({context: context, signature: signature});
                     });
                     return request;
                 };


### PR DESCRIPTION
Enhanced `defer` block load events to attach additional information to each event (specifically the defer block context and the nunjucks signature), as well as to fire an event on failure to load (`fragment_load_failed`). This allows clients to perform more robust event handling when a defer block finishes loading, without resorting to manually rendering the defer block contents.

Originally implemented in [this commit](https://github.com/cvan/galaxy/commit/f9ef1fb9e861fea610ba0ccda2e6c4099b25760e) from [galaxy/144](https://github.com/cvan/galaxy/pull/144), uplifted to commonplace as suggested by @cvan. See [this](https://github.com/cvan/galaxy/commit/f9ef1fb9e861fea610ba0ccda2e6c4099b25760e#diff-9e755bb262a8cce692b229d6e2d8b3caR88) for an example of how it can be used and why it's useful.
