### PR TITLE
Make RE_PLURALIZER non-greedy to fix parsing of weird (but valid) .po files

### DIFF
--- a/lib/generate_langpacks.js
+++ b/lib/generate_langpacks.js
@@ -7,7 +7,7 @@ var S_STR = 'msgstr ';
 var S_PLURAL = 'msgid_plural ';
 var S_PLURAL_STR = 'msgstr[';
 var RE_PLURAL = /^msgstr\[([0-9]+)\] (\".*\")/;
-var RE_PLURALIZER = /^Plural\-Forms: nplurals=[0-9]+; plural=(.+);/;
+var RE_PLURALIZER = /^Plural\-Forms: nplurals=[0-9]+; plural=(.+?);/;
 
 function parse(po_content) {
     var output = {};


### PR DESCRIPTION
Needed to make .po containing plural forms like these work:
`"Plural-Forms: nplurals=2; plural=(n != 1);Content-Type: text/plain; "`
