### PR TITLE
add offset back to jquery

### DIFF
--- a/src/media/js/lib/jquery-2.0.2.js
+++ b/src/media/js/lib/jquery-2.0.2.js
@@ -1,5 +1,5 @@
 /*!
- * jQuery JavaScript Library v2.0.2 -sizzle,-wrap,-event-alias,-ajax,-ajax/script,-ajax/jsonp,-ajax/xhr,-effects,-offset,-deprecated
+ * jQuery JavaScript Library v2.0.2 -sizzle,-event-alias,-ajax,-ajax/script,-ajax/jsonp,-ajax/xhr,-effects,-deprecated
  * http://jquery.com/
  *
  * Includes Sizzle.js
@@ -9,7 +9,7 @@
  * Released under the MIT license
  * http://jquery.org/license
  *
- * Date: 2013-06-06T23:32Z
+ * Date: 2013-06-03T15:33Z
  */
 (function( window, undefined ) {
 
@@ -19,847 +19,847 @@
 // Support: Firefox 18+
 //"use strict";
 var
-	// A central reference to the root jQuery(document)
-	rootjQuery,
+    // A central reference to the root jQuery(document)
+    rootjQuery,
 
-	// The deferred used on DOM ready
-	readyList,
+    // The deferred used on DOM ready
+    readyList,
 
-	// Support: IE9
-	// For `typeof xmlNode.method` instead of `xmlNode.method !== undefined`
-	core_strundefined = typeof undefined,
+    // Support: IE9
+    // For `typeof xmlNode.method` instead of `xmlNode.method !== undefined`
+    core_strundefined = typeof undefined,
 
-	// Use the correct document accordingly with window argument (sandbox)
-	location = window.location,
-	document = window.document,
-	docElem = document.documentElement,
+    // Use the correct document accordingly with window argument (sandbox)
+    location = window.location,
+    document = window.document,
+    docElem = document.documentElement,
 
-	// Map over jQuery in case of overwrite
-	_jQuery = window.jQuery,
+    // Map over jQuery in case of overwrite
+    _jQuery = window.jQuery,
 
-	// Map over the $ in case of overwrite
-	_$ = window.$,
+    // Map over the $ in case of overwrite
+    _$ = window.$,
 
-	// [[Class]] -> type pairs
-	class2type = {},
+    // [[Class]] -> type pairs
+    class2type = {},
 
-	// List of deleted data cache ids, so we can reuse them
-	core_deletedIds = [],
+    // List of deleted data cache ids, so we can reuse them
+    core_deletedIds = [],
 
-	core_version = "2.0.2 -sizzle,-wrap,-event-alias,-ajax,-ajax/script,-ajax/jsonp,-ajax/xhr,-effects,-offset,-deprecated",
+    core_version = "2.0.2 -sizzle,-event-alias,-ajax,-ajax/script,-ajax/jsonp,-ajax/xhr,-effects,-deprecated",
 
-	// Save a reference to some core methods
-	core_concat = core_deletedIds.concat,
-	core_push = core_deletedIds.push,
-	core_slice = core_deletedIds.slice,
-	core_indexOf = core_deletedIds.indexOf,
-	core_toString = class2type.toString,
-	core_hasOwn = class2type.hasOwnProperty,
-	core_trim = core_version.trim,
+    // Save a reference to some core methods
+    core_concat = core_deletedIds.concat,
+    core_push = core_deletedIds.push,
+    core_slice = core_deletedIds.slice,
+    core_indexOf = core_deletedIds.indexOf,
+    core_toString = class2type.toString,
+    core_hasOwn = class2type.hasOwnProperty,
+    core_trim = core_version.trim,
 
-	// Define a local copy of jQuery
-	jQuery = function( selector, context ) {
-		// The jQuery object is actually just the init constructor 'enhanced'
-		return new jQuery.fn.init( selector, context, rootjQuery );
-	},
+    // Define a local copy of jQuery
+    jQuery = function( selector, context ) {
+        // The jQuery object is actually just the init constructor 'enhanced'
+        return new jQuery.fn.init( selector, context, rootjQuery );
+    },
 
-	// Used for matching numbers
-	core_pnum = /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,
+    // Used for matching numbers
+    core_pnum = /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,
 
-	// Used for splitting on whitespace
-	core_rnotwhite = /\S+/g,
+    // Used for splitting on whitespace
+    core_rnotwhite = /\S+/g,
 
-	// A simple way to check for HTML strings
-	// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
-	// Strict HTML recognition (#11290: must start with <)
-	rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,
+    // A simple way to check for HTML strings
+    // Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
+    // Strict HTML recognition (#11290: must start with <)
+    rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,
 
-	// Match a standalone tag
-	rsingleTag = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
+    // Match a standalone tag
+    rsingleTag = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
 
-	// Matches dashed string for camelizing
-	rmsPrefix = /^-ms-/,
-	rdashAlpha = /-([\da-z])/gi,
+    // Matches dashed string for camelizing
+    rmsPrefix = /^-ms-/,
+    rdashAlpha = /-([\da-z])/gi,
 
-	// Used by jQuery.camelCase as callback to replace()
-	fcamelCase = function( all, letter ) {
-		return letter.toUpperCase();
-	},
+    // Used by jQuery.camelCase as callback to replace()
+    fcamelCase = function( all, letter ) {
+        return letter.toUpperCase();
+    },
 
-	// The ready event handler and self cleanup method
-	completed = function() {
-		document.removeEventListener( "DOMContentLoaded", completed, false );
-		window.removeEventListener( "load", completed, false );
-		jQuery.ready();
-	};
+    // The ready event handler and self cleanup method
+    completed = function() {
+        document.removeEventListener( "DOMContentLoaded", completed, false );
+        window.removeEventListener( "load", completed, false );
+        jQuery.ready();
+    };
 
 jQuery.fn = jQuery.prototype = {
-	// The current version of jQuery being used
-	jquery: core_version,
+    // The current version of jQuery being used
+    jquery: core_version,
 
-	constructor: jQuery,
-	init: function( selector, context, rootjQuery ) {
-		var match, elem;
+    constructor: jQuery,
+    init: function( selector, context, rootjQuery ) {
+        var match, elem;
 
-		// HANDLE: $(""), $(null), $(undefined), $(false)
-		if ( !selector ) {
-			return this;
-		}
+        // HANDLE: $(""), $(null), $(undefined), $(false)
+        if ( !selector ) {
+            return this;
+        }
 
-		// Handle HTML strings
-		if ( typeof selector === "string" ) {
-			if ( selector.charAt(0) === "<" && selector.charAt( selector.length - 1 ) === ">" && selector.length >= 3 ) {
-				// Assume that strings that start and end with <> are HTML and skip the regex check
-				match = [ null, selector, null ];
+        // Handle HTML strings
+        if ( typeof selector === "string" ) {
+            if ( selector.charAt(0) === "<" && selector.charAt( selector.length - 1 ) === ">" && selector.length >= 3 ) {
+                // Assume that strings that start and end with <> are HTML and skip the regex check
+                match = [ null, selector, null ];
 
-			} else {
-				match = rquickExpr.exec( selector );
-			}
+            } else {
+                match = rquickExpr.exec( selector );
+            }
 
-			// Match html or make sure no context is specified for #id
-			if ( match && (match[1] || !context) ) {
+            // Match html or make sure no context is specified for #id
+            if ( match && (match[1] || !context) ) {
 
-				// HANDLE: $(html) -> $(array)
-				if ( match[1] ) {
-					context = context instanceof jQuery ? context[0] : context;
+                // HANDLE: $(html) -> $(array)
+                if ( match[1] ) {
+                    context = context instanceof jQuery ? context[0] : context;
 
-					// scripts is true for back-compat
-					jQuery.merge( this, jQuery.parseHTML(
-						match[1],
-						context && context.nodeType ? context.ownerDocument || context : document,
-						true
-					) );
+                    // scripts is true for back-compat
+                    jQuery.merge( this, jQuery.parseHTML(
+                        match[1],
+                        context && context.nodeType ? context.ownerDocument || context : document,
+                        true
+                    ) );
 
-					// HANDLE: $(html, props)
-					if ( rsingleTag.test( match[1] ) && jQuery.isPlainObject( context ) ) {
-						for ( match in context ) {
-							// Properties of context are called as methods if possible
-							if ( jQuery.isFunction( this[ match ] ) ) {
-								this[ match ]( context[ match ] );
+                    // HANDLE: $(html, props)
+                    if ( rsingleTag.test( match[1] ) && jQuery.isPlainObject( context ) ) {
+                        for ( match in context ) {
+                            // Properties of context are called as methods if possible
+                            if ( jQuery.isFunction( this[ match ] ) ) {
+                                this[ match ]( context[ match ] );
 
-							// ...and otherwise set as attributes
-							} else {
-								this.attr( match, context[ match ] );
-							}
-						}
-					}
+                            // ...and otherwise set as attributes
+                            } else {
+                                this.attr( match, context[ match ] );
+                            }
+                        }
+                    }
 
-					return this;
+                    return this;
 
-				// HANDLE: $(#id)
-				} else {
-					elem = document.getElementById( match[2] );
+                // HANDLE: $(#id)
+                } else {
+                    elem = document.getElementById( match[2] );
 
-					// Check parentNode to catch when Blackberry 4.6 returns
-					// nodes that are no longer in the document #6963
-					if ( elem && elem.parentNode ) {
-						// Inject the element directly into the jQuery object
-						this.length = 1;
-						this[0] = elem;
-					}
+                    // Check parentNode to catch when Blackberry 4.6 returns
+                    // nodes that are no longer in the document #6963
+                    if ( elem && elem.parentNode ) {
+                        // Inject the element directly into the jQuery object
+                        this.length = 1;
+                        this[0] = elem;
+                    }
 
-					this.context = document;
-					this.selector = selector;
-					return this;
-				}
+                    this.context = document;
+                    this.selector = selector;
+                    return this;
+                }
 
-			// HANDLE: $(expr, $(...))
-			} else if ( !context || context.jquery ) {
-				return ( context || rootjQuery ).find( selector );
+            // HANDLE: $(expr, $(...))
+            } else if ( !context || context.jquery ) {
+                return ( context || rootjQuery ).find( selector );
 
-			// HANDLE: $(expr, context)
-			// (which is just equivalent to: $(context).find(expr)
-			} else {
-				return this.constructor( context ).find( selector );
-			}
+            // HANDLE: $(expr, context)
+            // (which is just equivalent to: $(context).find(expr)
+            } else {
+                return this.constructor( context ).find( selector );
+            }
 
-		// HANDLE: $(DOMElement)
-		} else if ( selector.nodeType ) {
-			this.context = this[0] = selector;
-			this.length = 1;
-			return this;
+        // HANDLE: $(DOMElement)
+        } else if ( selector.nodeType ) {
+            this.context = this[0] = selector;
+            this.length = 1;
+            return this;
 
-		// HANDLE: $(function)
-		// Shortcut for document ready
-		} else if ( jQuery.isFunction( selector ) ) {
-			return rootjQuery.ready( selector );
-		}
+        // HANDLE: $(function)
+        // Shortcut for document ready
+        } else if ( jQuery.isFunction( selector ) ) {
+            return rootjQuery.ready( selector );
+        }
 
-		if ( selector.selector !== undefined ) {
-			this.selector = selector.selector;
-			this.context = selector.context;
-		}
+        if ( selector.selector !== undefined ) {
+            this.selector = selector.selector;
+            this.context = selector.context;
+        }
 
-		return jQuery.makeArray( selector, this );
-	},
+        return jQuery.makeArray( selector, this );
+    },
 
-	// Start with an empty selector
-	selector: "",
+    // Start with an empty selector
+    selector: "",
 
-	// The default length of a jQuery object is 0
-	length: 0,
+    // The default length of a jQuery object is 0
+    length: 0,
 
-	toArray: function() {
-		return core_slice.call( this );
-	},
+    toArray: function() {
+        return core_slice.call( this );
+    },
 
-	// Get the Nth element in the matched element set OR
-	// Get the whole matched element set as a clean array
-	get: function( num ) {
-		return num == null ?
+    // Get the Nth element in the matched element set OR
+    // Get the whole matched element set as a clean array
+    get: function( num ) {
+        return num == null ?
 
-			// Return a 'clean' array
-			this.toArray() :
+            // Return a 'clean' array
+            this.toArray() :
 
-			// Return just the object
-			( num < 0 ? this[ this.length + num ] : this[ num ] );
-	},
+            // Return just the object
+            ( num < 0 ? this[ this.length + num ] : this[ num ] );
+    },
 
-	// Take an array of elements and push it onto the stack
-	// (returning the new matched element set)
-	pushStack: function( elems ) {
+    // Take an array of elements and push it onto the stack
+    // (returning the new matched element set)
+    pushStack: function( elems ) {
 
-		// Build a new jQuery matched element set
-		var ret = jQuery.merge( this.constructor(), elems );
+        // Build a new jQuery matched element set
+        var ret = jQuery.merge( this.constructor(), elems );
 
-		// Add the old object onto the stack (as a reference)
-		ret.prevObject = this;
-		ret.context = this.context;
+        // Add the old object onto the stack (as a reference)
+        ret.prevObject = this;
+        ret.context = this.context;
 
-		// Return the newly-formed element set
-		return ret;
-	},
+        // Return the newly-formed element set
+        return ret;
+    },
 
-	// Execute a callback for every element in the matched set.
-	// (You can seed the arguments with an array of args, but this is
-	// only used internally.)
-	each: function( callback, args ) {
-		return jQuery.each( this, callback, args );
-	},
+    // Execute a callback for every element in the matched set.
+    // (You can seed the arguments with an array of args, but this is
+    // only used internally.)
+    each: function( callback, args ) {
+        return jQuery.each( this, callback, args );
+    },
 
-	ready: function( fn ) {
-		// Add the callback
-		jQuery.ready.promise().done( fn );
+    ready: function( fn ) {
+        // Add the callback
+        jQuery.ready.promise().done( fn );
 
-		return this;
-	},
+        return this;
+    },
 
-	slice: function() {
-		return this.pushStack( core_slice.apply( this, arguments ) );
-	},
+    slice: function() {
+        return this.pushStack( core_slice.apply( this, arguments ) );
+    },
 
-	first: function() {
-		return this.eq( 0 );
-	},
+    first: function() {
+        return this.eq( 0 );
+    },
 
-	last: function() {
-		return this.eq( -1 );
-	},
+    last: function() {
+        return this.eq( -1 );
+    },
 
-	eq: function( i ) {
-		var len = this.length,
-			j = +i + ( i < 0 ? len : 0 );
-		return this.pushStack( j >= 0 && j < len ? [ this[j] ] : [] );
-	},
+    eq: function( i ) {
+        var len = this.length,
+            j = +i + ( i < 0 ? len : 0 );
+        return this.pushStack( j >= 0 && j < len ? [ this[j] ] : [] );
+    },
 
-	map: function( callback ) {
-		return this.pushStack( jQuery.map(this, function( elem, i ) {
-			return callback.call( elem, i, elem );
-		}));
-	},
+    map: function( callback ) {
+        return this.pushStack( jQuery.map(this, function( elem, i ) {
+            return callback.call( elem, i, elem );
+        }));
+    },
 
-	end: function() {
-		return this.prevObject || this.constructor(null);
-	},
+    end: function() {
+        return this.prevObject || this.constructor(null);
+    },
 
-	// For internal use only.
-	// Behaves like an Array's method, not like a jQuery method.
-	push: core_push,
-	sort: [].sort,
-	splice: [].splice
+    // For internal use only.
+    // Behaves like an Array's method, not like a jQuery method.
+    push: core_push,
+    sort: [].sort,
+    splice: [].splice
 };
 
 // Give the init function the jQuery prototype for later instantiation
 jQuery.fn.init.prototype = jQuery.fn;
 
 jQuery.extend = jQuery.fn.extend = function() {
-	var options, name, src, copy, copyIsArray, clone,
-		target = arguments[0] || {},
-		i = 1,
-		length = arguments.length,
-		deep = false;
+    var options, name, src, copy, copyIsArray, clone,
+        target = arguments[0] || {},
+        i = 1,
+        length = arguments.length,
+        deep = false;
 
-	// Handle a deep copy situation
-	if ( typeof target === "boolean" ) {
-		deep = target;
-		target = arguments[1] || {};
-		// skip the boolean and the target
-		i = 2;
-	}
+    // Handle a deep copy situation
+    if ( typeof target === "boolean" ) {
+        deep = target;
+        target = arguments[1] || {};
+        // skip the boolean and the target
+        i = 2;
+    }
 
-	// Handle case when target is a string or something (possible in deep copy)
-	if ( typeof target !== "object" && !jQuery.isFunction(target) ) {
-		target = {};
-	}
+    // Handle case when target is a string or something (possible in deep copy)
+    if ( typeof target !== "object" && !jQuery.isFunction(target) ) {
+        target = {};
+    }
 
-	// extend jQuery itself if only one argument is passed
-	if ( length === i ) {
-		target = this;
-		--i;
-	}
+    // extend jQuery itself if only one argument is passed
+    if ( length === i ) {
+        target = this;
+        --i;
+    }
 
-	for ( ; i < length; i++ ) {
-		// Only deal with non-null/undefined values
-		if ( (options = arguments[ i ]) != null ) {
-			// Extend the base object
-			for ( name in options ) {
-				src = target[ name ];
-				copy = options[ name ];
+    for ( ; i < length; i++ ) {
+        // Only deal with non-null/undefined values
+        if ( (options = arguments[ i ]) != null ) {
+            // Extend the base object
+            for ( name in options ) {
+                src = target[ name ];
+                copy = options[ name ];
 
-				// Prevent never-ending loop
-				if ( target === copy ) {
-					continue;
-				}
+                // Prevent never-ending loop
+                if ( target === copy ) {
+                    continue;
+                }
 
-				// Recurse if we're merging plain objects or arrays
-				if ( deep && copy && ( jQuery.isPlainObject(copy) || (copyIsArray = jQuery.isArray(copy)) ) ) {
-					if ( copyIsArray ) {
-						copyIsArray = false;
-						clone = src && jQuery.isArray(src) ? src : [];
+                // Recurse if we're merging plain objects or arrays
+                if ( deep && copy && ( jQuery.isPlainObject(copy) || (copyIsArray = jQuery.isArray(copy)) ) ) {
+                    if ( copyIsArray ) {
+                        copyIsArray = false;
+                        clone = src && jQuery.isArray(src) ? src : [];
 
-					} else {
-						clone = src && jQuery.isPlainObject(src) ? src : {};
-					}
+                    } else {
+                        clone = src && jQuery.isPlainObject(src) ? src : {};
+                    }
 
-					// Never move original objects, clone them
-					target[ name ] = jQuery.extend( deep, clone, copy );
+                    // Never move original objects, clone them
+                    target[ name ] = jQuery.extend( deep, clone, copy );
 
-				// Don't bring in undefined values
-				} else if ( copy !== undefined ) {
-					target[ name ] = copy;
-				}
-			}
-		}
-	}
+                // Don't bring in undefined values
+                } else if ( copy !== undefined ) {
+                    target[ name ] = copy;
+                }
+            }
+        }
+    }
 
-	// Return the modified object
-	return target;
+    // Return the modified object
+    return target;
 };
 
 jQuery.extend({
-	// Unique for each copy of jQuery on the page
-	expando: "jQuery" + ( core_version + Math.random() ).replace( /\D/g, "" ),
-
-	noConflict: function( deep ) {
-		if ( window.$ === jQuery ) {
-			window.$ = _$;
-		}
-
-		if ( deep && window.jQuery === jQuery ) {
-			window.jQuery = _jQuery;
-		}
-
-		return jQuery;
-	},
-
-	// Is the DOM ready to be used? Set to true once it occurs.
-	isReady: false,
-
-	// A counter to track how many items to wait for before
-	// the ready event fires. See #6781
-	readyWait: 1,
-
-	// Hold (or release) the ready event
-	holdReady: function( hold ) {
-		if ( hold ) {
-			jQuery.readyWait++;
-		} else {
-			jQuery.ready( true );
-		}
-	},
-
-	// Handle when the DOM is ready
-	ready: function( wait ) {
-
-		// Abort if there are pending holds or we're already ready
-		if ( wait === true ? --jQuery.readyWait : jQuery.isReady ) {
-			return;
-		}
-
-		// Remember that the DOM is ready
-		jQuery.isReady = true;
-
-		// If a normal DOM Ready event fired, decrement, and wait if need be
-		if ( wait !== true && --jQuery.readyWait > 0 ) {
-			return;
-		}
-
-		// If there are functions bound, to execute
-		readyList.resolveWith( document, [ jQuery ] );
-
-		// Trigger any bound ready events
-		if ( jQuery.fn.trigger ) {
-			jQuery( document ).trigger("ready").off("ready");
-		}
-	},
-
-	// See test/unit/core.js for details concerning isFunction.
-	// Since version 1.3, DOM methods and functions like alert
-	// aren't supported. They return false on IE (#2968).
-	isFunction: function( obj ) {
-		return jQuery.type(obj) === "function";
-	},
-
-	isArray: Array.isArray,
-
-	isWindow: function( obj ) {
-		return obj != null && obj === obj.window;
-	},
-
-	isNumeric: function( obj ) {
-		return !isNaN( parseFloat(obj) ) && isFinite( obj );
-	},
-
-	type: function( obj ) {
-		if ( obj == null ) {
-			return String( obj );
-		}
-		// Support: Safari <= 5.1 (functionish RegExp)
-		return typeof obj === "object" || typeof obj === "function" ?
-			class2type[ core_toString.call(obj) ] || "object" :
-			typeof obj;
-	},
-
-	isPlainObject: function( obj ) {
-		// Not plain objects:
-		// - Any object or value whose internal [[Class]] property is not "[object Object]"
-		// - DOM nodes
-		// - window
-		if ( jQuery.type( obj ) !== "object" || obj.nodeType || jQuery.isWindow( obj ) ) {
-			return false;
-		}
-
-		// Support: Firefox <20
-		// The try/catch suppresses exceptions thrown when attempting to access
-		// the "constructor" property of certain host objects, ie. |window.location|
-		// https://bugzilla.mozilla.org/show_bug.cgi?id=814622
-		try {
-			if ( obj.constructor &&
-					!core_hasOwn.call( obj.constructor.prototype, "isPrototypeOf" ) ) {
-				return false;
-			}
-		} catch ( e ) {
-			return false;
-		}
-
-		// If the function hasn't returned already, we're confident that
-		// |obj| is a plain object, created by {} or constructed with new Object
-		return true;
-	},
-
-	isEmptyObject: function( obj ) {
-		var name;
-		for ( name in obj ) {
-			return false;
-		}
-		return true;
-	},
-
-	error: function( msg ) {
-		throw new Error( msg );
-	},
-
-	// data: string of html
-	// context (optional): If specified, the fragment will be created in this context, defaults to document
-	// keepScripts (optional): If true, will include scripts passed in the html string
-	parseHTML: function( data, context, keepScripts ) {
-		if ( !data || typeof data !== "string" ) {
-			return null;
-		}
-		if ( typeof context === "boolean" ) {
-			keepScripts = context;
-			context = false;
-		}
-		context = context || document;
-
-		var parsed = rsingleTag.exec( data ),
-			scripts = !keepScripts && [];
-
-		// Single tag
-		if ( parsed ) {
-			return [ context.createElement( parsed[1] ) ];
-		}
-
-		parsed = jQuery.buildFragment( [ data ], context, scripts );
-
-		if ( scripts ) {
-			jQuery( scripts ).remove();
-		}
-
-		return jQuery.merge( [], parsed.childNodes );
-	},
-
-	parseJSON: JSON.parse,
-
-	// Cross-browser xml parsing
-	parseXML: function( data ) {
-		var xml, tmp;
-		if ( !data || typeof data !== "string" ) {
-			return null;
-		}
-
-		// Support: IE9
-		try {
-			tmp = new DOMParser();
-			xml = tmp.parseFromString( data , "text/xml" );
-		} catch ( e ) {
-			xml = undefined;
-		}
-
-		if ( !xml || xml.getElementsByTagName( "parsererror" ).length ) {
-			jQuery.error( "Invalid XML: " + data );
-		}
-		return xml;
-	},
-
-	noop: function() {},
-
-	// Evaluates a script in a global context
-	globalEval: function( code ) {
-		var script,
-				indirect = eval;
-
-		code = jQuery.trim( code );
-
-		if ( code ) {
-			// If the code includes a valid, prologue position
-			// strict mode pragma, execute code by injecting a
-			// script tag into the document.
-			if ( code.indexOf("use strict") === 1 ) {
-				script = document.createElement("script");
-				script.text = code;
-				document.head.appendChild( script ).parentNode.removeChild( script );
-			} else {
-			// Otherwise, avoid the DOM node creation, insertion
-			// and removal by using an indirect global eval
-				indirect( code );
-			}
-		}
-	},
-
-	// Convert dashed to camelCase; used by the css and data modules
-	// Microsoft forgot to hump their vendor prefix (#9572)
-	camelCase: function( string ) {
-		return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
-	},
-
-	nodeName: function( elem, name ) {
-		return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
-	},
-
-	// args is for internal usage only
-	each: function( obj, callback, args ) {
-		var value,
-			i = 0,
-			length = obj.length,
-			isArray = isArraylike( obj );
-
-		if ( args ) {
-			if ( isArray ) {
-				for ( ; i < length; i++ ) {
-					value = callback.apply( obj[ i ], args );
-
-					if ( value === false ) {
-						break;
-					}
-				}
-			} else {
-				for ( i in obj ) {
-					value = callback.apply( obj[ i ], args );
-
-					if ( value === false ) {
-						break;
-					}
-				}
-			}
-
-		// A special, fast, case for the most common use of each
-		} else {
-			if ( isArray ) {
-				for ( ; i < length; i++ ) {
-					value = callback.call( obj[ i ], i, obj[ i ] );
-
-					if ( value === false ) {
-						break;
-					}
-				}
-			} else {
-				for ( i in obj ) {
-					value = callback.call( obj[ i ], i, obj[ i ] );
-
-					if ( value === false ) {
-						break;
-					}
-				}
-			}
-		}
-
-		return obj;
-	},
-
-	trim: function( text ) {
-		return text == null ? "" : core_trim.call( text );
-	},
-
-	// results is for internal usage only
-	makeArray: function( arr, results ) {
-		var ret = results || [];
-
-		if ( arr != null ) {
-			if ( isArraylike( Object(arr) ) ) {
-				jQuery.merge( ret,
-					typeof arr === "string" ?
-					[ arr ] : arr
-				);
-			} else {
-				core_push.call( ret, arr );
-			}
-		}
-
-		return ret;
-	},
-
-	inArray: function( elem, arr, i ) {
-		return arr == null ? -1 : core_indexOf.call( arr, elem, i );
-	},
-
-	merge: function( first, second ) {
-		var l = second.length,
-			i = first.length,
-			j = 0;
-
-		if ( typeof l === "number" ) {
-			for ( ; j < l; j++ ) {
-				first[ i++ ] = second[ j ];
-			}
-		} else {
-			while ( second[j] !== undefined ) {
-				first[ i++ ] = second[ j++ ];
-			}
-		}
-
-		first.length = i;
-
-		return first;
-	},
-
-	grep: function( elems, callback, inv ) {
-		var retVal,
-			ret = [],
-			i = 0,
-			length = elems.length;
-		inv = !!inv;
-
-		// Go through the array, only saving the items
-		// that pass the validator function
-		for ( ; i < length; i++ ) {
-			retVal = !!callback( elems[ i ], i );
-			if ( inv !== retVal ) {
-				ret.push( elems[ i ] );
-			}
-		}
-
-		return ret;
-	},
-
-	// arg is for internal usage only
-	map: function( elems, callback, arg ) {
-		var value,
-			i = 0,
-			length = elems.length,
-			isArray = isArraylike( elems ),
-			ret = [];
-
-		// Go through the array, translating each of the items to their
-		if ( isArray ) {
-			for ( ; i < length; i++ ) {
-				value = callback( elems[ i ], i, arg );
-
-				if ( value != null ) {
-					ret[ ret.length ] = value;
-				}
-			}
-
-		// Go through every key on the object,
-		} else {
-			for ( i in elems ) {
-				value = callback( elems[ i ], i, arg );
-
-				if ( value != null ) {
-					ret[ ret.length ] = value;
-				}
-			}
-		}
-
-		// Flatten any nested arrays
-		return core_concat.apply( [], ret );
-	},
-
-	// A global GUID counter for objects
-	guid: 1,
-
-	// Bind a function to a context, optionally partially applying any
-	// arguments.
-	proxy: function( fn, context ) {
-		var tmp, args, proxy;
-
-		if ( typeof context === "string" ) {
-			tmp = fn[ context ];
-			context = fn;
-			fn = tmp;
-		}
-
-		// Quick check to determine if target is callable, in the spec
-		// this throws a TypeError, but we will just return undefined.
-		if ( !jQuery.isFunction( fn ) ) {
-			return undefined;
-		}
-
-		// Simulated bind
-		args = core_slice.call( arguments, 2 );
-		proxy = function() {
-			return fn.apply( context || this, args.concat( core_slice.call( arguments ) ) );
-		};
-
-		// Set the guid of unique handler to the same of original handler, so it can be removed
-		proxy.guid = fn.guid = fn.guid || jQuery.guid++;
-
-		return proxy;
-	},
-
-	// Multifunctional method to get and set values of a collection
-	// The value/s can optionally be executed if it's a function
-	access: function( elems, fn, key, value, chainable, emptyGet, raw ) {
-		var i = 0,
-			length = elems.length,
-			bulk = key == null;
-
-		// Sets many values
-		if ( jQuery.type( key ) === "object" ) {
-			chainable = true;
-			for ( i in key ) {
-				jQuery.access( elems, fn, i, key[i], true, emptyGet, raw );
-			}
-
-		// Sets one value
-		} else if ( value !== undefined ) {
-			chainable = true;
-
-			if ( !jQuery.isFunction( value ) ) {
-				raw = true;
-			}
-
-			if ( bulk ) {
-				// Bulk operations run against the entire set
-				if ( raw ) {
-					fn.call( elems, value );
-					fn = null;
-
-				// ...except when executing function values
-				} else {
-					bulk = fn;
-					fn = function( elem, key, value ) {
-						return bulk.call( jQuery( elem ), value );
-					};
-				}
-			}
-
-			if ( fn ) {
-				for ( ; i < length; i++ ) {
-					fn( elems[i], key, raw ? value : value.call( elems[i], i, fn( elems[i], key ) ) );
-				}
-			}
-		}
-
-		return chainable ?
-			elems :
-
-			// Gets
-			bulk ?
-				fn.call( elems ) :
-				length ? fn( elems[0], key ) : emptyGet;
-	},
-
-	now: Date.now,
-
-	// A method for quickly swapping in/out CSS properties to get correct calculations.
-	// Note: this method belongs to the css module but it's needed here for the support module.
-	// If support gets modularized, this method should be moved back to the css module.
-	swap: function( elem, options, callback, args ) {
-		var ret, name,
-			old = {};
-
-		// Remember the old values, and insert the new ones
-		for ( name in options ) {
-			old[ name ] = elem.style[ name ];
-			elem.style[ name ] = options[ name ];
-		}
-
-		ret = callback.apply( elem, args || [] );
-
-		// Revert the old values
-		for ( name in options ) {
-			elem.style[ name ] = old[ name ];
-		}
-
-		return ret;
-	}
+    // Unique for each copy of jQuery on the page
+    expando: "jQuery" + ( core_version + Math.random() ).replace( /\D/g, "" ),
+
+    noConflict: function( deep ) {
+        if ( window.$ === jQuery ) {
+            window.$ = _$;
+        }
+
+        if ( deep && window.jQuery === jQuery ) {
+            window.jQuery = _jQuery;
+        }
+
+        return jQuery;
+    },
+
+    // Is the DOM ready to be used? Set to true once it occurs.
+    isReady: false,
+
+    // A counter to track how many items to wait for before
+    // the ready event fires. See #6781
+    readyWait: 1,
+
+    // Hold (or release) the ready event
+    holdReady: function( hold ) {
+        if ( hold ) {
+            jQuery.readyWait++;
+        } else {
+            jQuery.ready( true );
+        }
+    },
+
+    // Handle when the DOM is ready
+    ready: function( wait ) {
+
+        // Abort if there are pending holds or we're already ready
+        if ( wait === true ? --jQuery.readyWait : jQuery.isReady ) {
+            return;
+        }
+
+        // Remember that the DOM is ready
+        jQuery.isReady = true;
+
+        // If a normal DOM Ready event fired, decrement, and wait if need be
+        if ( wait !== true && --jQuery.readyWait > 0 ) {
+            return;
+        }
+
+        // If there are functions bound, to execute
+        readyList.resolveWith( document, [ jQuery ] );
+
+        // Trigger any bound ready events
+        if ( jQuery.fn.trigger ) {
+            jQuery( document ).trigger("ready").off("ready");
+        }
+    },
+
+    // See test/unit/core.js for details concerning isFunction.
+    // Since version 1.3, DOM methods and functions like alert
+    // aren't supported. They return false on IE (#2968).
+    isFunction: function( obj ) {
+        return jQuery.type(obj) === "function";
+    },
+
+    isArray: Array.isArray,
+
+    isWindow: function( obj ) {
+        return obj != null && obj === obj.window;
+    },
+
+    isNumeric: function( obj ) {
+        return !isNaN( parseFloat(obj) ) && isFinite( obj );
+    },
+
+    type: function( obj ) {
+        if ( obj == null ) {
+            return String( obj );
+        }
+        // Support: Safari <= 5.1 (functionish RegExp)
+        return typeof obj === "object" || typeof obj === "function" ?
+            class2type[ core_toString.call(obj) ] || "object" :
+            typeof obj;
+    },
+
+    isPlainObject: function( obj ) {
+        // Not plain objects:
+        // - Any object or value whose internal [[Class]] property is not "[object Object]"
+        // - DOM nodes
+        // - window
+        if ( jQuery.type( obj ) !== "object" || obj.nodeType || jQuery.isWindow( obj ) ) {
+            return false;
+        }
+
+        // Support: Firefox <20
+        // The try/catch suppresses exceptions thrown when attempting to access
+        // the "constructor" property of certain host objects, ie. |window.location|
+        // https://bugzilla.mozilla.org/show_bug.cgi?id=814622
+        try {
+            if ( obj.constructor &&
+                    !core_hasOwn.call( obj.constructor.prototype, "isPrototypeOf" ) ) {
+                return false;
+            }
+        } catch ( e ) {
+            return false;
+        }
+
+        // If the function hasn't returned already, we're confident that
+        // |obj| is a plain object, created by {} or constructed with new Object
+        return true;
+    },
+
+    isEmptyObject: function( obj ) {
+        var name;
+        for ( name in obj ) {
+            return false;
+        }
+        return true;
+    },
+
+    error: function( msg ) {
+        throw new Error( msg );
+    },
+
+    // data: string of html
+    // context (optional): If specified, the fragment will be created in this context, defaults to document
+    // keepScripts (optional): If true, will include scripts passed in the html string
+    parseHTML: function( data, context, keepScripts ) {
+        if ( !data || typeof data !== "string" ) {
+            return null;
+        }
+        if ( typeof context === "boolean" ) {
+            keepScripts = context;
+            context = false;
+        }
+        context = context || document;
+
+        var parsed = rsingleTag.exec( data ),
+            scripts = !keepScripts && [];
+
+        // Single tag
+        if ( parsed ) {
+            return [ context.createElement( parsed[1] ) ];
+        }
+
+        parsed = jQuery.buildFragment( [ data ], context, scripts );
+
+        if ( scripts ) {
+            jQuery( scripts ).remove();
+        }
+
+        return jQuery.merge( [], parsed.childNodes );
+    },
+
+    parseJSON: JSON.parse,
+
+    // Cross-browser xml parsing
+    parseXML: function( data ) {
+        var xml, tmp;
+        if ( !data || typeof data !== "string" ) {
+            return null;
+        }
+
+        // Support: IE9
+        try {
+            tmp = new DOMParser();
+            xml = tmp.parseFromString( data , "text/xml" );
+        } catch ( e ) {
+            xml = undefined;
+        }
+
+        if ( !xml || xml.getElementsByTagName( "parsererror" ).length ) {
+            jQuery.error( "Invalid XML: " + data );
+        }
+        return xml;
+    },
+
+    noop: function() {},
+
+    // Evaluates a script in a global context
+    globalEval: function( code ) {
+        var script,
+                indirect = eval;
+
+        code = jQuery.trim( code );
+
+        if ( code ) {
+            // If the code includes a valid, prologue position
+            // strict mode pragma, execute code by injecting a
+            // script tag into the document.
+            if ( code.indexOf("use strict") === 1 ) {
+                script = document.createElement("script");
+                script.text = code;
+                document.head.appendChild( script ).parentNode.removeChild( script );
+            } else {
+            // Otherwise, avoid the DOM node creation, insertion
+            // and removal by using an indirect global eval
+                indirect( code );
+            }
+        }
+    },
+
+    // Convert dashed to camelCase; used by the css and data modules
+    // Microsoft forgot to hump their vendor prefix (#9572)
+    camelCase: function( string ) {
+        return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
+    },
+
+    nodeName: function( elem, name ) {
+        return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
+    },
+
+    // args is for internal usage only
+    each: function( obj, callback, args ) {
+        var value,
+            i = 0,
+            length = obj.length,
+            isArray = isArraylike( obj );
+
+        if ( args ) {
+            if ( isArray ) {
+                for ( ; i < length; i++ ) {
+                    value = callback.apply( obj[ i ], args );
+
+                    if ( value === false ) {
+                        break;
+                    }
+                }
+            } else {
+                for ( i in obj ) {
+                    value = callback.apply( obj[ i ], args );
+
+                    if ( value === false ) {
+                        break;
+                    }
+                }
+            }
+
+        // A special, fast, case for the most common use of each
+        } else {
+            if ( isArray ) {
+                for ( ; i < length; i++ ) {
+                    value = callback.call( obj[ i ], i, obj[ i ] );
+
+                    if ( value === false ) {
+                        break;
+                    }
+                }
+            } else {
+                for ( i in obj ) {
+                    value = callback.call( obj[ i ], i, obj[ i ] );
+
+                    if ( value === false ) {
+                        break;
+                    }
+                }
+            }
+        }
+
+        return obj;
+    },
+
+    trim: function( text ) {
+        return text == null ? "" : core_trim.call( text );
+    },
+
+    // results is for internal usage only
+    makeArray: function( arr, results ) {
+        var ret = results || [];
+
+        if ( arr != null ) {
+            if ( isArraylike( Object(arr) ) ) {
+                jQuery.merge( ret,
+                    typeof arr === "string" ?
+                    [ arr ] : arr
+                );
+            } else {
+                core_push.call( ret, arr );
+            }
+        }
+
+        return ret;
+    },
+
+    inArray: function( elem, arr, i ) {
+        return arr == null ? -1 : core_indexOf.call( arr, elem, i );
+    },
+
+    merge: function( first, second ) {
+        var l = second.length,
+            i = first.length,
+            j = 0;
+
+        if ( typeof l === "number" ) {
+            for ( ; j < l; j++ ) {
+                first[ i++ ] = second[ j ];
+            }
+        } else {
+            while ( second[j] !== undefined ) {
+                first[ i++ ] = second[ j++ ];
+            }
+        }
+
+        first.length = i;
+
+        return first;
+    },
+
+    grep: function( elems, callback, inv ) {
+        var retVal,
+            ret = [],
+            i = 0,
+            length = elems.length;
+        inv = !!inv;
+
+        // Go through the array, only saving the items
+        // that pass the validator function
+        for ( ; i < length; i++ ) {
+            retVal = !!callback( elems[ i ], i );
+            if ( inv !== retVal ) {
+                ret.push( elems[ i ] );
+            }
+        }
+
+        return ret;
+    },
+
+    // arg is for internal usage only
+    map: function( elems, callback, arg ) {
+        var value,
+            i = 0,
+            length = elems.length,
+            isArray = isArraylike( elems ),
+            ret = [];
+
+        // Go through the array, translating each of the items to their
+        if ( isArray ) {
+            for ( ; i < length; i++ ) {
+                value = callback( elems[ i ], i, arg );
+
+                if ( value != null ) {
+                    ret[ ret.length ] = value;
+                }
+            }
+
+        // Go through every key on the object,
+        } else {
+            for ( i in elems ) {
+                value = callback( elems[ i ], i, arg );
+
+                if ( value != null ) {
+                    ret[ ret.length ] = value;
+                }
+            }
+        }
+
+        // Flatten any nested arrays
+        return core_concat.apply( [], ret );
+    },
+
+    // A global GUID counter for objects
+    guid: 1,
+
+    // Bind a function to a context, optionally partially applying any
+    // arguments.
+    proxy: function( fn, context ) {
+        var tmp, args, proxy;
+
+        if ( typeof context === "string" ) {
+            tmp = fn[ context ];
+            context = fn;
+            fn = tmp;
+        }
+
+        // Quick check to determine if target is callable, in the spec
+        // this throws a TypeError, but we will just return undefined.
+        if ( !jQuery.isFunction( fn ) ) {
+            return undefined;
+        }
+
+        // Simulated bind
+        args = core_slice.call( arguments, 2 );
+        proxy = function() {
+            return fn.apply( context || this, args.concat( core_slice.call( arguments ) ) );
+        };
+
+        // Set the guid of unique handler to the same of original handler, so it can be removed
+        proxy.guid = fn.guid = fn.guid || jQuery.guid++;
+
+        return proxy;
+    },
+
+    // Multifunctional method to get and set values of a collection
+    // The value/s can optionally be executed if it's a function
+    access: function( elems, fn, key, value, chainable, emptyGet, raw ) {
+        var i = 0,
+            length = elems.length,
+            bulk = key == null;
+
+        // Sets many values
+        if ( jQuery.type( key ) === "object" ) {
+            chainable = true;
+            for ( i in key ) {
+                jQuery.access( elems, fn, i, key[i], true, emptyGet, raw );
+            }
+
+        // Sets one value
+        } else if ( value !== undefined ) {
+            chainable = true;
+
+            if ( !jQuery.isFunction( value ) ) {
+                raw = true;
+            }
+
+            if ( bulk ) {
+                // Bulk operations run against the entire set
+                if ( raw ) {
+                    fn.call( elems, value );
+                    fn = null;
+
+                // ...except when executing function values
+                } else {
+                    bulk = fn;
+                    fn = function( elem, key, value ) {
+                        return bulk.call( jQuery( elem ), value );
+                    };
+                }
+            }
+
+            if ( fn ) {
+                for ( ; i < length; i++ ) {
+                    fn( elems[i], key, raw ? value : value.call( elems[i], i, fn( elems[i], key ) ) );
+                }
+            }
+        }
+
+        return chainable ?
+            elems :
+
+            // Gets
+            bulk ?
+                fn.call( elems ) :
+                length ? fn( elems[0], key ) : emptyGet;
+    },
+
+    now: Date.now,
+
+    // A method for quickly swapping in/out CSS properties to get correct calculations.
+    // Note: this method belongs to the css module but it's needed here for the support module.
+    // If support gets modularized, this method should be moved back to the css module.
+    swap: function( elem, options, callback, args ) {
+        var ret, name,
+            old = {};
+
+        // Remember the old values, and insert the new ones
+        for ( name in options ) {
+            old[ name ] = elem.style[ name ];
+            elem.style[ name ] = options[ name ];
+        }
+
+        ret = callback.apply( elem, args || [] );
+
+        // Revert the old values
+        for ( name in options ) {
+            elem.style[ name ] = old[ name ];
+        }
+
+        return ret;
+    }
 });
 
 jQuery.ready.promise = function( obj ) {
-	if ( !readyList ) {
+    if ( !readyList ) {
 
-		readyList = jQuery.Deferred();
+        readyList = jQuery.Deferred();
 
-		// Catch cases where $(document).ready() is called after the browser event has already occurred.
-		// we once tried to use readyState "interactive" here, but it caused issues like the one
-		// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
-		if ( document.readyState === "complete" ) {
-			// Handle it asynchronously to allow scripts the opportunity to delay ready
-			setTimeout( jQuery.ready );
+        // Catch cases where $(document).ready() is called after the browser event has already occurred.
+        // we once tried to use readyState "interactive" here, but it caused issues like the one
+        // discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
+        if ( document.readyState === "complete" ) {
+            // Handle it asynchronously to allow scripts the opportunity to delay ready
+            setTimeout( jQuery.ready );
 
-		} else {
+        } else {
 
-			// Use the handy event callback
-			document.addEventListener( "DOMContentLoaded", completed, false );
+            // Use the handy event callback
+            document.addEventListener( "DOMContentLoaded", completed, false );
 
-			// A fallback to window.onload, that will always work
-			window.addEventListener( "load", completed, false );
-		}
-	}
-	return readyList.promise( obj );
+            // A fallback to window.onload, that will always work
+            window.addEventListener( "load", completed, false );
+        }
+    }
+    return readyList.promise( obj );
 };
 
 // Populate the class2type map
 jQuery.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(i, name) {
-	class2type[ "[object " + name + "]" ] = name.toLowerCase();
+    class2type[ "[object " + name + "]" ] = name.toLowerCase();
 });
 
 function isArraylike( obj ) {
-	var length = obj.length,
-		type = jQuery.type( obj );
+    var length = obj.length,
+        type = jQuery.type( obj );
 
-	if ( jQuery.isWindow( obj ) ) {
-		return false;
-	}
+    if ( jQuery.isWindow( obj ) ) {
+        return false;
+    }
 
-	if ( obj.nodeType === 1 && length ) {
-		return true;
-	}
+    if ( obj.nodeType === 1 && length ) {
+        return true;
+    }
 
-	return type === "array" || type !== "function" &&
-		( length === 0 ||
-		typeof length === "number" && length > 0 && ( length - 1 ) in obj );
+    return type === "array" || type !== "function" &&
+        ( length === 0 ||
+        typeof length === "number" && length > 0 && ( length - 1 ) in obj );
 }
 
 // All jQuery objects should point back to these
@@ -890,786 +890,786 @@ rootjQuery = jQuery(document);
  */
 
 var selector_hasDuplicate,
-	matches = docElem.webkitMatchesSelector ||
-		docElem.mozMatchesSelector ||
-		docElem.oMatchesSelector ||
-		docElem.msMatchesSelector,
-	selector_sortOrder = function( a, b ) {
-		// Flag for duplicate removal
-		if ( a === b ) {
-			selector_hasDuplicate = true;
-			return 0;
-		}
+    matches = docElem.webkitMatchesSelector ||
+        docElem.mozMatchesSelector ||
+        docElem.oMatchesSelector ||
+        docElem.msMatchesSelector,
+    selector_sortOrder = function( a, b ) {
+        // Flag for duplicate removal
+        if ( a === b ) {
+            selector_hasDuplicate = true;
+            return 0;
+        }
 
-		var compare = b.compareDocumentPosition && a.compareDocumentPosition && a.compareDocumentPosition( b );
+        var compare = b.compareDocumentPosition && a.compareDocumentPosition && a.compareDocumentPosition( b );
 
-		if ( compare ) {
-			// Disconnected nodes
-			if ( compare & 1 ) {
+        if ( compare ) {
+            // Disconnected nodes
+            if ( compare & 1 ) {
 
-				// Choose the first element that is related to our document
-				if ( a === document || jQuery.contains(document, a) ) {
-					return -1;
-				}
-				if ( b === document || jQuery.contains(document, b) ) {
-					return 1;
-				}
+                // Choose the first element that is related to our document
+                if ( a === document || jQuery.contains(document, a) ) {
+                    return -1;
+                }
+                if ( b === document || jQuery.contains(document, b) ) {
+                    return 1;
+                }
 
-				// Maintain original order
-				return 0;
-			}
+                // Maintain original order
+                return 0;
+            }
 
-			return compare & 4 ? -1 : 1;
-		}
+            return compare & 4 ? -1 : 1;
+        }
 
-		// Not directly comparable, sort on existence of method
-		return a.compareDocumentPosition ? -1 : 1;
-	};
+        // Not directly comparable, sort on existence of method
+        return a.compareDocumentPosition ? -1 : 1;
+    };
 
 jQuery.extend({
-	find: function( selector, context, results, seed ) {
-		var elem, nodeType,
-			i = 0;
+    find: function( selector, context, results, seed ) {
+        var elem, nodeType,
+            i = 0;
 
-		results = results || [];
-		context = context || document;
+        results = results || [];
+        context = context || document;
 
-		// Same basic safeguard as Sizzle
-		if ( !selector || typeof selector !== "string" ) {
-			return results;
-		}
+        // Same basic safeguard as Sizzle
+        if ( !selector || typeof selector !== "string" ) {
+            return results;
+        }
 
-		// Early return if context is not an element or document
-		if ( (nodeType = context.nodeType) !== 1 && nodeType !== 9 ) {
-			return [];
-		}
+        // Early return if context is not an element or document
+        if ( (nodeType = context.nodeType) !== 1 && nodeType !== 9 ) {
+            return [];
+        }
 
-		if ( seed ) {
-			while ( (elem = seed[i++]) ) {
-				if ( jQuery.find.matchesSelector(elem, selector) ) {
-					results.push( elem );
-				}
-			}
-		} else {
-			jQuery.merge( results, context.querySelectorAll(selector) );
-		}
+        if ( seed ) {
+            while ( (elem = seed[i++]) ) {
+                if ( jQuery.find.matchesSelector(elem, selector) ) {
+                    results.push( elem );
+                }
+            }
+        } else {
+            jQuery.merge( results, context.querySelectorAll(selector) );
+        }
 
-		return results;
-	},
-	unique: function( results ) {
-		var elem,
-			duplicates = [],
-			i = 0,
-			j = 0;
+        return results;
+    },
+    unique: function( results ) {
+        var elem,
+            duplicates = [],
+            i = 0,
+            j = 0;
 
-		selector_hasDuplicate = false;
-		results.sort( selector_sortOrder );
+        selector_hasDuplicate = false;
+        results.sort( selector_sortOrder );
 
-		if ( selector_hasDuplicate ) {
-			while ( (elem = results[i++]) ) {
-				if ( elem === results[ i ] ) {
-					j = duplicates.push( i );
-				}
-			}
-			while ( j-- ) {
-				results.splice( duplicates[ j ], 1 );
-			}
-		}
+        if ( selector_hasDuplicate ) {
+            while ( (elem = results[i++]) ) {
+                if ( elem === results[ i ] ) {
+                    j = duplicates.push( i );
+                }
+            }
+            while ( j-- ) {
+                results.splice( duplicates[ j ], 1 );
+            }
+        }
 
-		return results;
-	},
-	text: function( elem ) {
-		var node,
-			ret = "",
-			i = 0,
-			nodeType = elem.nodeType;
+        return results;
+    },
+    text: function( elem ) {
+        var node,
+            ret = "",
+            i = 0,
+            nodeType = elem.nodeType;
 
-		if ( !nodeType ) {
-			// If no nodeType, this is expected to be an array
-			while ( (node = elem[i++]) ) {
-				// Do not traverse comment nodes
-				ret += jQuery.text( node );
-			}
-		} else if ( nodeType === 1 || nodeType === 9 || nodeType === 11 ) {
-			// Use textContent for elements
-			return elem.textContent;
-		} else if ( nodeType === 3 || nodeType === 4 ) {
-			return elem.nodeValue;
-		}
-		// Do not include comment or processing instruction nodes
+        if ( !nodeType ) {
+            // If no nodeType, this is expected to be an array
+            while ( (node = elem[i++]) ) {
+                // Do not traverse comment nodes
+                ret += jQuery.text( node );
+            }
+        } else if ( nodeType === 1 || nodeType === 9 || nodeType === 11 ) {
+            // Use textContent for elements
+            return elem.textContent;
+        } else if ( nodeType === 3 || nodeType === 4 ) {
+            return elem.nodeValue;
+        }
+        // Do not include comment or processing instruction nodes
 
-		return ret;
-	},
-	contains: function( a, b ) {
-		var adown = a.nodeType === 9 ? a.documentElement : a,
-			bup = b && b.parentNode;
-		return a === bup || !!( bup && bup.nodeType === 1 && adown.contains(bup) );
-	},
-	isXMLDoc: function( elem ) {
-		return (elem.ownerDocument || elem).documentElement.nodeName !== "HTML";
-	},
-	expr: {
-		attrHandle: {},
-		match: {
-			bool: /^(?:checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped)$/i,
-			needsContext: /^[\x20\t\r\n\f]*[>+~]/
-		}
-	}
+        return ret;
+    },
+    contains: function( a, b ) {
+        var adown = a.nodeType === 9 ? a.documentElement : a,
+            bup = b && b.parentNode;
+        return a === bup || !!( bup && bup.nodeType === 1 && adown.contains(bup) );
+    },
+    isXMLDoc: function( elem ) {
+        return (elem.ownerDocument || elem).documentElement.nodeName !== "HTML";
+    },
+    expr: {
+        attrHandle: {},
+        match: {
+            bool: /^(?:checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped)$/i,
+            needsContext: /^[\x20\t\r\n\f]*[>+~]/
+        }
+    }
 });
 
 jQuery.extend( jQuery.find, {
-	matches: function( expr, elements ) {
-		return jQuery.find( expr, null, null, elements );
-	},
-	matchesSelector: function( elem, expr ) {
-		return matches.call( elem, expr );
-	},
-	attr: function( elem, name ) {
-		return elem.getAttribute( name );
-	}
+    matches: function( expr, elements ) {
+        return jQuery.find( expr, null, null, elements );
+    },
+    matchesSelector: function( elem, expr ) {
+        return matches.call( elem, expr );
+    },
+    attr: function( elem, name ) {
+        return elem.getAttribute( name );
+    }
 });
 // String to Object options format cache
 var optionsCache = {};
 
 // Convert String-formatted options into Object-formatted ones and store in cache
 function createOptions( options ) {
-	var object = optionsCache[ options ] = {};
-	jQuery.each( options.match( core_rnotwhite ) || [], function( _, flag ) {
-		object[ flag ] = true;
-	});
-	return object;
+    var object = optionsCache[ options ] = {};
+    jQuery.each( options.match( core_rnotwhite ) || [], function( _, flag ) {
+        object[ flag ] = true;
+    });
+    return object;
 }
 
 /*
  * Create a callback list using the following parameters:
  *
- *	options: an optional list of space-separated options that will change how
- *			the callback list behaves or a more traditional option object
+ *  options: an optional list of space-separated options that will change how
+ *          the callback list behaves or a more traditional option object
  *
  * By default a callback list will act like an event callback list and can be
  * "fired" multiple times.
  *
  * Possible options:
  *
- *	once:			will ensure the callback list can only be fired once (like a Deferred)
+ *  once:           will ensure the callback list can only be fired once (like a Deferred)
  *
- *	memory:			will keep track of previous values and will call any callback added
- *					after the list has been fired right away with the latest "memorized"
- *					values (like a Deferred)
+ *  memory:         will keep track of previous values and will call any callback added
+ *                  after the list has been fired right away with the latest "memorized"
+ *                  values (like a Deferred)
  *
- *	unique:			will ensure a callback can only be added once (no duplicate in the list)
+ *  unique:         will ensure a callback can only be added once (no duplicate in the list)
  *
- *	stopOnFalse:	interrupt callings when a callback returns false
+ *  stopOnFalse:    interrupt callings when a callback returns false
  *
  */
 jQuery.Callbacks = function( options ) {
 
-	// Convert options from String-formatted to Object-formatted if needed
-	// (we check in cache first)
-	options = typeof options === "string" ?
-		( optionsCache[ options ] || createOptions( options ) ) :
-		jQuery.extend( {}, options );
+    // Convert options from String-formatted to Object-formatted if needed
+    // (we check in cache first)
+    options = typeof options === "string" ?
+        ( optionsCache[ options ] || createOptions( options ) ) :
+        jQuery.extend( {}, options );
 
-	var // Last fire value (for non-forgettable lists)
-		memory,
-		// Flag to know if list was already fired
-		fired,
-		// Flag to know if list is currently firing
-		firing,
-		// First callback to fire (used internally by add and fireWith)
-		firingStart,
-		// End of the loop when firing
-		firingLength,
-		// Index of currently firing callback (modified by remove if needed)
-		firingIndex,
-		// Actual callback list
-		list = [],
-		// Stack of fire calls for repeatable lists
-		stack = !options.once && [],
-		// Fire callbacks
-		fire = function( data ) {
-			memory = options.memory && data;
-			fired = true;
-			firingIndex = firingStart || 0;
-			firingStart = 0;
-			firingLength = list.length;
-			firing = true;
-			for ( ; list && firingIndex < firingLength; firingIndex++ ) {
-				if ( list[ firingIndex ].apply( data[ 0 ], data[ 1 ] ) === false && options.stopOnFalse ) {
-					memory = false; // To prevent further calls using add
-					break;
-				}
-			}
-			firing = false;
-			if ( list ) {
-				if ( stack ) {
-					if ( stack.length ) {
-						fire( stack.shift() );
-					}
-				} else if ( memory ) {
-					list = [];
-				} else {
-					self.disable();
-				}
-			}
-		},
-		// Actual Callbacks object
-		self = {
-			// Add a callback or a collection of callbacks to the list
-			add: function() {
-				if ( list ) {
-					// First, we save the current length
-					var start = list.length;
-					(function add( args ) {
-						jQuery.each( args, function( _, arg ) {
-							var type = jQuery.type( arg );
-							if ( type === "function" ) {
-								if ( !options.unique || !self.has( arg ) ) {
-									list.push( arg );
-								}
-							} else if ( arg && arg.length && type !== "string" ) {
-								// Inspect recursively
-								add( arg );
-							}
-						});
-					})( arguments );
-					// Do we need to add the callbacks to the
-					// current firing batch?
-					if ( firing ) {
-						firingLength = list.length;
-					// With memory, if we're not firing then
-					// we should call right away
-					} else if ( memory ) {
-						firingStart = start;
-						fire( memory );
-					}
-				}
-				return this;
-			},
-			// Remove a callback from the list
-			remove: function() {
-				if ( list ) {
-					jQuery.each( arguments, function( _, arg ) {
-						var index;
-						while( ( index = jQuery.inArray( arg, list, index ) ) > -1 ) {
-							list.splice( index, 1 );
-							// Handle firing indexes
-							if ( firing ) {
-								if ( index <= firingLength ) {
-									firingLength--;
-								}
-								if ( index <= firingIndex ) {
-									firingIndex--;
-								}
-							}
-						}
-					});
-				}
-				return this;
-			},
-			// Check if a given callback is in the list.
-			// If no argument is given, return whether or not list has callbacks attached.
-			has: function( fn ) {
-				return fn ? jQuery.inArray( fn, list ) > -1 : !!( list && list.length );
-			},
-			// Remove all callbacks from the list
-			empty: function() {
-				list = [];
-				firingLength = 0;
-				return this;
-			},
-			// Have the list do nothing anymore
-			disable: function() {
-				list = stack = memory = undefined;
-				return this;
-			},
-			// Is it disabled?
-			disabled: function() {
-				return !list;
-			},
-			// Lock the list in its current state
-			lock: function() {
-				stack = undefined;
-				if ( !memory ) {
-					self.disable();
-				}
-				return this;
-			},
-			// Is it locked?
-			locked: function() {
-				return !stack;
-			},
-			// Call all callbacks with the given context and arguments
-			fireWith: function( context, args ) {
-				args = args || [];
-				args = [ context, args.slice ? args.slice() : args ];
-				if ( list && ( !fired || stack ) ) {
-					if ( firing ) {
-						stack.push( args );
-					} else {
-						fire( args );
-					}
-				}
-				return this;
-			},
-			// Call all the callbacks with the given arguments
-			fire: function() {
-				self.fireWith( this, arguments );
-				return this;
-			},
-			// To know if the callbacks have already been called at least once
-			fired: function() {
-				return !!fired;
-			}
-		};
+    var // Last fire value (for non-forgettable lists)
+        memory,
+        // Flag to know if list was already fired
+        fired,
+        // Flag to know if list is currently firing
+        firing,
+        // First callback to fire (used internally by add and fireWith)
+        firingStart,
+        // End of the loop when firing
+        firingLength,
+        // Index of currently firing callback (modified by remove if needed)
+        firingIndex,
+        // Actual callback list
+        list = [],
+        // Stack of fire calls for repeatable lists
+        stack = !options.once && [],
+        // Fire callbacks
+        fire = function( data ) {
+            memory = options.memory && data;
+            fired = true;
+            firingIndex = firingStart || 0;
+            firingStart = 0;
+            firingLength = list.length;
+            firing = true;
+            for ( ; list && firingIndex < firingLength; firingIndex++ ) {
+                if ( list[ firingIndex ].apply( data[ 0 ], data[ 1 ] ) === false && options.stopOnFalse ) {
+                    memory = false; // To prevent further calls using add
+                    break;
+                }
+            }
+            firing = false;
+            if ( list ) {
+                if ( stack ) {
+                    if ( stack.length ) {
+                        fire( stack.shift() );
+                    }
+                } else if ( memory ) {
+                    list = [];
+                } else {
+                    self.disable();
+                }
+            }
+        },
+        // Actual Callbacks object
+        self = {
+            // Add a callback or a collection of callbacks to the list
+            add: function() {
+                if ( list ) {
+                    // First, we save the current length
+                    var start = list.length;
+                    (function add( args ) {
+                        jQuery.each( args, function( _, arg ) {
+                            var type = jQuery.type( arg );
+                            if ( type === "function" ) {
+                                if ( !options.unique || !self.has( arg ) ) {
+                                    list.push( arg );
+                                }
+                            } else if ( arg && arg.length && type !== "string" ) {
+                                // Inspect recursively
+                                add( arg );
+                            }
+                        });
+                    })( arguments );
+                    // Do we need to add the callbacks to the
+                    // current firing batch?
+                    if ( firing ) {
+                        firingLength = list.length;
+                    // With memory, if we're not firing then
+                    // we should call right away
+                    } else if ( memory ) {
+                        firingStart = start;
+                        fire( memory );
+                    }
+                }
+                return this;
+            },
+            // Remove a callback from the list
+            remove: function() {
+                if ( list ) {
+                    jQuery.each( arguments, function( _, arg ) {
+                        var index;
+                        while( ( index = jQuery.inArray( arg, list, index ) ) > -1 ) {
+                            list.splice( index, 1 );
+                            // Handle firing indexes
+                            if ( firing ) {
+                                if ( index <= firingLength ) {
+                                    firingLength--;
+                                }
+                                if ( index <= firingIndex ) {
+                                    firingIndex--;
+                                }
+                            }
+                        }
+                    });
+                }
+                return this;
+            },
+            // Check if a given callback is in the list.
+            // If no argument is given, return whether or not list has callbacks attached.
+            has: function( fn ) {
+                return fn ? jQuery.inArray( fn, list ) > -1 : !!( list && list.length );
+            },
+            // Remove all callbacks from the list
+            empty: function() {
+                list = [];
+                firingLength = 0;
+                return this;
+            },
+            // Have the list do nothing anymore
+            disable: function() {
+                list = stack = memory = undefined;
+                return this;
+            },
+            // Is it disabled?
+            disabled: function() {
+                return !list;
+            },
+            // Lock the list in its current state
+            lock: function() {
+                stack = undefined;
+                if ( !memory ) {
+                    self.disable();
+                }
+                return this;
+            },
+            // Is it locked?
+            locked: function() {
+                return !stack;
+            },
+            // Call all callbacks with the given context and arguments
+            fireWith: function( context, args ) {
+                args = args || [];
+                args = [ context, args.slice ? args.slice() : args ];
+                if ( list && ( !fired || stack ) ) {
+                    if ( firing ) {
+                        stack.push( args );
+                    } else {
+                        fire( args );
+                    }
+                }
+                return this;
+            },
+            // Call all the callbacks with the given arguments
+            fire: function() {
+                self.fireWith( this, arguments );
+                return this;
+            },
+            // To know if the callbacks have already been called at least once
+            fired: function() {
+                return !!fired;
+            }
+        };
 
-	return self;
+    return self;
 };
 jQuery.extend({
 
-	Deferred: function( func ) {
-		var tuples = [
-				// action, add listener, listener list, final state
-				[ "resolve", "done", jQuery.Callbacks("once memory"), "resolved" ],
-				[ "reject", "fail", jQuery.Callbacks("once memory"), "rejected" ],
-				[ "notify", "progress", jQuery.Callbacks("memory") ]
-			],
-			state = "pending",
-			promise = {
-				state: function() {
-					return state;
-				},
-				always: function() {
-					deferred.done( arguments ).fail( arguments );
-					return this;
-				},
-				then: function( /* fnDone, fnFail, fnProgress */ ) {
-					var fns = arguments;
-					return jQuery.Deferred(function( newDefer ) {
-						jQuery.each( tuples, function( i, tuple ) {
-							var action = tuple[ 0 ],
-								fn = jQuery.isFunction( fns[ i ] ) && fns[ i ];
-							// deferred[ done | fail | progress ] for forwarding actions to newDefer
-							deferred[ tuple[1] ](function() {
-								var returned = fn && fn.apply( this, arguments );
-								if ( returned && jQuery.isFunction( returned.promise ) ) {
-									returned.promise()
-										.done( newDefer.resolve )
-										.fail( newDefer.reject )
-										.progress( newDefer.notify );
-								} else {
-									newDefer[ action + "With" ]( this === promise ? newDefer.promise() : this, fn ? [ returned ] : arguments );
-								}
-							});
-						});
-						fns = null;
-					}).promise();
-				},
-				// Get a promise for this deferred
-				// If obj is provided, the promise aspect is added to the object
-				promise: function( obj ) {
-					return obj != null ? jQuery.extend( obj, promise ) : promise;
-				}
-			},
-			deferred = {};
+    Deferred: function( func ) {
+        var tuples = [
+                // action, add listener, listener list, final state
+                [ "resolve", "done", jQuery.Callbacks("once memory"), "resolved" ],
+                [ "reject", "fail", jQuery.Callbacks("once memory"), "rejected" ],
+                [ "notify", "progress", jQuery.Callbacks("memory") ]
+            ],
+            state = "pending",
+            promise = {
+                state: function() {
+                    return state;
+                },
+                always: function() {
+                    deferred.done( arguments ).fail( arguments );
+                    return this;
+                },
+                then: function( /* fnDone, fnFail, fnProgress */ ) {
+                    var fns = arguments;
+                    return jQuery.Deferred(function( newDefer ) {
+                        jQuery.each( tuples, function( i, tuple ) {
+                            var action = tuple[ 0 ],
+                                fn = jQuery.isFunction( fns[ i ] ) && fns[ i ];
+                            // deferred[ done | fail | progress ] for forwarding actions to newDefer
+                            deferred[ tuple[1] ](function() {
+                                var returned = fn && fn.apply( this, arguments );
+                                if ( returned && jQuery.isFunction( returned.promise ) ) {
+                                    returned.promise()
+                                        .done( newDefer.resolve )
+                                        .fail( newDefer.reject )
+                                        .progress( newDefer.notify );
+                                } else {
+                                    newDefer[ action + "With" ]( this === promise ? newDefer.promise() : this, fn ? [ returned ] : arguments );
+                                }
+                            });
+                        });
+                        fns = null;
+                    }).promise();
+                },
+                // Get a promise for this deferred
+                // If obj is provided, the promise aspect is added to the object
+                promise: function( obj ) {
+                    return obj != null ? jQuery.extend( obj, promise ) : promise;
+                }
+            },
+            deferred = {};
 
-		// Keep pipe for back-compat
-		promise.pipe = promise.then;
+        // Keep pipe for back-compat
+        promise.pipe = promise.then;
 
-		// Add list-specific methods
-		jQuery.each( tuples, function( i, tuple ) {
-			var list = tuple[ 2 ],
-				stateString = tuple[ 3 ];
+        // Add list-specific methods
+        jQuery.each( tuples, function( i, tuple ) {
+            var list = tuple[ 2 ],
+                stateString = tuple[ 3 ];
 
-			// promise[ done | fail | progress ] = list.add
-			promise[ tuple[1] ] = list.add;
+            // promise[ done | fail | progress ] = list.add
+            promise[ tuple[1] ] = list.add;
 
-			// Handle state
-			if ( stateString ) {
-				list.add(function() {
-					// state = [ resolved | rejected ]
-					state = stateString;
+            // Handle state
+            if ( stateString ) {
+                list.add(function() {
+                    // state = [ resolved | rejected ]
+                    state = stateString;
 
-				// [ reject_list | resolve_list ].disable; progress_list.lock
-				}, tuples[ i ^ 1 ][ 2 ].disable, tuples[ 2 ][ 2 ].lock );
-			}
+                // [ reject_list | resolve_list ].disable; progress_list.lock
+                }, tuples[ i ^ 1 ][ 2 ].disable, tuples[ 2 ][ 2 ].lock );
+            }
 
-			// deferred[ resolve | reject | notify ]
-			deferred[ tuple[0] ] = function() {
-				deferred[ tuple[0] + "With" ]( this === deferred ? promise : this, arguments );
-				return this;
-			};
-			deferred[ tuple[0] + "With" ] = list.fireWith;
-		});
+            // deferred[ resolve | reject | notify ]
+            deferred[ tuple[0] ] = function() {
+                deferred[ tuple[0] + "With" ]( this === deferred ? promise : this, arguments );
+                return this;
+            };
+            deferred[ tuple[0] + "With" ] = list.fireWith;
+        });
 
-		// Make the deferred a promise
-		promise.promise( deferred );
+        // Make the deferred a promise
+        promise.promise( deferred );
 
-		// Call given func if any
-		if ( func ) {
-			func.call( deferred, deferred );
-		}
+        // Call given func if any
+        if ( func ) {
+            func.call( deferred, deferred );
+        }
 
-		// All done!
-		return deferred;
-	},
+        // All done!
+        return deferred;
+    },
 
-	// Deferred helper
-	when: function( subordinate /* , ..., subordinateN */ ) {
-		var i = 0,
-			resolveValues = core_slice.call( arguments ),
-			length = resolveValues.length,
+    // Deferred helper
+    when: function( subordinate /* , ..., subordinateN */ ) {
+        var i = 0,
+            resolveValues = core_slice.call( arguments ),
+            length = resolveValues.length,
 
-			// the count of uncompleted subordinates
-			remaining = length !== 1 || ( subordinate && jQuery.isFunction( subordinate.promise ) ) ? length : 0,
+            // the count of uncompleted subordinates
+            remaining = length !== 1 || ( subordinate && jQuery.isFunction( subordinate.promise ) ) ? length : 0,
 
-			// the master Deferred. If resolveValues consist of only a single Deferred, just use that.
-			deferred = remaining === 1 ? subordinate : jQuery.Deferred(),
+            // the master Deferred. If resolveValues consist of only a single Deferred, just use that.
+            deferred = remaining === 1 ? subordinate : jQuery.Deferred(),
 
-			// Update function for both resolve and progress values
-			updateFunc = function( i, contexts, values ) {
-				return function( value ) {
-					contexts[ i ] = this;
-					values[ i ] = arguments.length > 1 ? core_slice.call( arguments ) : value;
-					if( values === progressValues ) {
-						deferred.notifyWith( contexts, values );
-					} else if ( !( --remaining ) ) {
-						deferred.resolveWith( contexts, values );
-					}
-				};
-			},
+            // Update function for both resolve and progress values
+            updateFunc = function( i, contexts, values ) {
+                return function( value ) {
+                    contexts[ i ] = this;
+                    values[ i ] = arguments.length > 1 ? core_slice.call( arguments ) : value;
+                    if( values === progressValues ) {
+                        deferred.notifyWith( contexts, values );
+                    } else if ( !( --remaining ) ) {
+                        deferred.resolveWith( contexts, values );
+                    }
+                };
+            },
 
-			progressValues, progressContexts, resolveContexts;
+            progressValues, progressContexts, resolveContexts;
 
-		// add listeners to Deferred subordinates; treat others as resolved
-		if ( length > 1 ) {
-			progressValues = new Array( length );
-			progressContexts = new Array( length );
-			resolveContexts = new Array( length );
-			for ( ; i < length; i++ ) {
-				if ( resolveValues[ i ] && jQuery.isFunction( resolveValues[ i ].promise ) ) {
-					resolveValues[ i ].promise()
-						.done( updateFunc( i, resolveContexts, resolveValues ) )
-						.fail( deferred.reject )
-						.progress( updateFunc( i, progressContexts, progressValues ) );
-				} else {
-					--remaining;
-				}
-			}
-		}
+        // add listeners to Deferred subordinates; treat others as resolved
+        if ( length > 1 ) {
+            progressValues = new Array( length );
+            progressContexts = new Array( length );
+            resolveContexts = new Array( length );
+            for ( ; i < length; i++ ) {
+                if ( resolveValues[ i ] && jQuery.isFunction( resolveValues[ i ].promise ) ) {
+                    resolveValues[ i ].promise()
+                        .done( updateFunc( i, resolveContexts, resolveValues ) )
+                        .fail( deferred.reject )
+                        .progress( updateFunc( i, progressContexts, progressValues ) );
+                } else {
+                    --remaining;
+                }
+            }
+        }
 
-		// if we're not waiting on anything, resolve the master
-		if ( !remaining ) {
-			deferred.resolveWith( resolveContexts, resolveValues );
-		}
+        // if we're not waiting on anything, resolve the master
+        if ( !remaining ) {
+            deferred.resolveWith( resolveContexts, resolveValues );
+        }
 
-		return deferred.promise();
-	}
+        return deferred.promise();
+    }
 });
 jQuery.support = (function( support ) {
-	var input = document.createElement("input"),
-		fragment = document.createDocumentFragment(),
-		div = document.createElement("div"),
-		select = document.createElement("select"),
-		opt = select.appendChild( document.createElement("option") );
+    var input = document.createElement("input"),
+        fragment = document.createDocumentFragment(),
+        div = document.createElement("div"),
+        select = document.createElement("select"),
+        opt = select.appendChild( document.createElement("option") );
 
-	// Finish early in limited environments
-	if ( !input.type ) {
-		return support;
-	}
+    // Finish early in limited environments
+    if ( !input.type ) {
+        return support;
+    }
 
-	input.type = "checkbox";
+    input.type = "checkbox";
 
-	// Support: Safari 5.1, iOS 5.1, Android 4.x, Android 2.3
-	// Check the default checkbox/radio value ("" on old WebKit; "on" elsewhere)
-	support.checkOn = input.value !== "";
+    // Support: Safari 5.1, iOS 5.1, Android 4.x, Android 2.3
+    // Check the default checkbox/radio value ("" on old WebKit; "on" elsewhere)
+    support.checkOn = input.value !== "";
 
-	// Must access the parent to make an option select properly
-	// Support: IE9, IE10
-	support.optSelected = opt.selected;
+    // Must access the parent to make an option select properly
+    // Support: IE9, IE10
+    support.optSelected = opt.selected;
 
-	// Will be defined later
-	support.reliableMarginRight = true;
-	support.boxSizingReliable = true;
-	support.pixelPosition = false;
+    // Will be defined later
+    support.reliableMarginRight = true;
+    support.boxSizingReliable = true;
+    support.pixelPosition = false;
 
-	// Make sure checked status is properly cloned
-	// Support: IE9, IE10
-	input.checked = true;
-	support.noCloneChecked = input.cloneNode( true ).checked;
+    // Make sure checked status is properly cloned
+    // Support: IE9, IE10
+    input.checked = true;
+    support.noCloneChecked = input.cloneNode( true ).checked;
 
-	// Make sure that the options inside disabled selects aren't marked as disabled
-	// (WebKit marks them as disabled)
-	select.disabled = true;
-	support.optDisabled = !opt.disabled;
+    // Make sure that the options inside disabled selects aren't marked as disabled
+    // (WebKit marks them as disabled)
+    select.disabled = true;
+    support.optDisabled = !opt.disabled;
 
-	// Check if an input maintains its value after becoming a radio
-	// Support: IE9, IE10
-	input = document.createElement("input");
-	input.value = "t";
-	input.type = "radio";
-	support.radioValue = input.value === "t";
+    // Check if an input maintains its value after becoming a radio
+    // Support: IE9, IE10
+    input = document.createElement("input");
+    input.value = "t";
+    input.type = "radio";
+    support.radioValue = input.value === "t";
 
-	// #11217 - WebKit loses check when the name is after the checked attribute
-	input.setAttribute( "checked", "t" );
-	input.setAttribute( "name", "t" );
+    // #11217 - WebKit loses check when the name is after the checked attribute
+    input.setAttribute( "checked", "t" );
+    input.setAttribute( "name", "t" );
 
-	fragment.appendChild( input );
+    fragment.appendChild( input );
 
-	// Support: Safari 5.1, Android 4.x, Android 2.3
-	// old WebKit doesn't clone checked state correctly in fragments
-	support.checkClone = fragment.cloneNode( true ).cloneNode( true ).lastChild.checked;
+    // Support: Safari 5.1, Android 4.x, Android 2.3
+    // old WebKit doesn't clone checked state correctly in fragments
+    support.checkClone = fragment.cloneNode( true ).cloneNode( true ).lastChild.checked;
 
-	// Support: Firefox, Chrome, Safari
-	// Beware of CSP restrictions (https://developer.mozilla.org/en/Security/CSP)
-	support.focusinBubbles = "onfocusin" in window;
+    // Support: Firefox, Chrome, Safari
+    // Beware of CSP restrictions (https://developer.mozilla.org/en/Security/CSP)
+    support.focusinBubbles = "onfocusin" in window;
 
-	div.style.backgroundClip = "content-box";
-	div.cloneNode( true ).style.backgroundClip = "";
-	support.clearCloneStyle = div.style.backgroundClip === "content-box";
+    div.style.backgroundClip = "content-box";
+    div.cloneNode( true ).style.backgroundClip = "";
+    support.clearCloneStyle = div.style.backgroundClip === "content-box";
 
-	// Run tests that need a body at doc ready
-	jQuery(function() {
-		var container, marginDiv,
-			// Support: Firefox, Android 2.3 (Prefixed box-sizing versions).
-			divReset = "padding:0;margin:0;border:0;display:block;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box",
-			body = document.getElementsByTagName("body")[ 0 ];
+    // Run tests that need a body at doc ready
+    jQuery(function() {
+        var container, marginDiv,
+            // Support: Firefox, Android 2.3 (Prefixed box-sizing versions).
+            divReset = "padding:0;margin:0;border:0;display:block;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box",
+            body = document.getElementsByTagName("body")[ 0 ];
 
-		if ( !body ) {
-			// Return for frameset docs that don't have a body
-			return;
-		}
+        if ( !body ) {
+            // Return for frameset docs that don't have a body
+            return;
+        }
 
-		container = document.createElement("div");
-		container.style.cssText = "border:0;width:0;height:0;position:absolute;top:0;left:-9999px;margin-top:1px";
+        container = document.createElement("div");
+        container.style.cssText = "border:0;width:0;height:0;position:absolute;top:0;left:-9999px;margin-top:1px";
 
-		// Check box-sizing and margin behavior.
-		body.appendChild( container ).appendChild( div );
-		div.innerHTML = "";
-		// Support: Firefox, Android 2.3 (Prefixed box-sizing versions).
-		div.style.cssText = "-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%";
+        // Check box-sizing and margin behavior.
+        body.appendChild( container ).appendChild( div );
+        div.innerHTML = "";
+        // Support: Firefox, Android 2.3 (Prefixed box-sizing versions).
+        div.style.cssText = "-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%";
 
-		// Workaround failing boxSizing test due to offsetWidth returning wrong value
-		// with some non-1 values of body zoom, ticket #13543
-		jQuery.swap( body, body.style.zoom != null ? { zoom: 1 } : {}, function() {
-			support.boxSizing = div.offsetWidth === 4;
-		});
+        // Workaround failing boxSizing test due to offsetWidth returning wrong value
+        // with some non-1 values of body zoom, ticket #13543
+        jQuery.swap( body, body.style.zoom != null ? { zoom: 1 } : {}, function() {
+            support.boxSizing = div.offsetWidth === 4;
+        });
 
-		// Use window.getComputedStyle because jsdom on node.js will break without it.
-		if ( window.getComputedStyle ) {
-			support.pixelPosition = ( window.getComputedStyle( div, null ) || {} ).top !== "1%";
-			support.boxSizingReliable = ( window.getComputedStyle( div, null ) || { width: "4px" } ).width === "4px";
+        // Use window.getComputedStyle because jsdom on node.js will break without it.
+        if ( window.getComputedStyle ) {
+            support.pixelPosition = ( window.getComputedStyle( div, null ) || {} ).top !== "1%";
+            support.boxSizingReliable = ( window.getComputedStyle( div, null ) || { width: "4px" } ).width === "4px";
 
-			// Support: Android 2.3
-			// Check if div with explicit width and no margin-right incorrectly
-			// gets computed margin-right based on width of container. (#3333)
-			// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
-			marginDiv = div.appendChild( document.createElement("div") );
-			marginDiv.style.cssText = div.style.cssText = divReset;
-			marginDiv.style.marginRight = marginDiv.style.width = "0";
-			div.style.width = "1px";
+            // Support: Android 2.3
+            // Check if div with explicit width and no margin-right incorrectly
+            // gets computed margin-right based on width of container. (#3333)
+            // WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
+            marginDiv = div.appendChild( document.createElement("div") );
+            marginDiv.style.cssText = div.style.cssText = divReset;
+            marginDiv.style.marginRight = marginDiv.style.width = "0";
+            div.style.width = "1px";
 
-			support.reliableMarginRight =
-				!parseFloat( ( window.getComputedStyle( marginDiv, null ) || {} ).marginRight );
-		}
+            support.reliableMarginRight =
+                !parseFloat( ( window.getComputedStyle( marginDiv, null ) || {} ).marginRight );
+        }
 
-		body.removeChild( container );
-	});
+        body.removeChild( container );
+    });
 
-	return support;
+    return support;
 })( {} );
 
 /*
-	Implementation Summary
+    Implementation Summary
 
-	1. Enforce API surface and semantic compatibility with 1.9.x branch
-	2. Improve the module's maintainability by reducing the storage
-		paths to a single mechanism.
-	3. Use the same single mechanism to support "private" and "user" data.
-	4. _Never_ expose "private" data to user code (TODO: Drop _data, _removeData)
-	5. Avoid exposing implementation details on user objects (eg. expando properties)
-	6. Provide a clear path for implementation upgrade to WeakMap in 2014
+    1. Enforce API surface and semantic compatibility with 1.9.x branch
+    2. Improve the module's maintainability by reducing the storage
+        paths to a single mechanism.
+    3. Use the same single mechanism to support "private" and "user" data.
+    4. _Never_ expose "private" data to user code (TODO: Drop _data, _removeData)
+    5. Avoid exposing implementation details on user objects (eg. expando properties)
+    6. Provide a clear path for implementation upgrade to WeakMap in 2014
 */
 var data_user, data_priv,
-	rbrace = /(?:\{[\s\S]*\}|\[[\s\S]*\])$/,
-	rmultiDash = /([A-Z])/g;
+    rbrace = /(?:\{[\s\S]*\}|\[[\s\S]*\])$/,
+    rmultiDash = /([A-Z])/g;
 
 function Data() {
-	// Support: Android < 4,
-	// Old WebKit does not have Object.preventExtensions/freeze method,
-	// return new empty object instead with no [[set]] accessor
-	Object.defineProperty( this.cache = {}, 0, {
-		get: function() {
-			return {};
-		}
-	});
+    // Support: Android < 4,
+    // Old WebKit does not have Object.preventExtensions/freeze method,
+    // return new empty object instead with no [[set]] accessor
+    Object.defineProperty( this.cache = {}, 0, {
+        get: function() {
+            return {};
+        }
+    });
 
-	this.expando = jQuery.expando + Math.random();
+    this.expando = jQuery.expando + Math.random();
 }
 
 Data.uid = 1;
 
 Data.accepts = function( owner ) {
-	// Accepts only:
-	//  - Node
-	//    - Node.ELEMENT_NODE
-	//    - Node.DOCUMENT_NODE
-	//  - Object
-	//    - Any
-	return owner.nodeType ?
-		owner.nodeType === 1 || owner.nodeType === 9 : true;
+    // Accepts only:
+    //  - Node
+    //    - Node.ELEMENT_NODE
+    //    - Node.DOCUMENT_NODE
+    //  - Object
+    //    - Any
+    return owner.nodeType ?
+        owner.nodeType === 1 || owner.nodeType === 9 : true;
 };
 
 Data.prototype = {
-	key: function( owner ) {
-		// We can accept data for non-element nodes in modern browsers,
-		// but we should not, see #8335.
-		// Always return the key for a frozen object.
-		if ( !Data.accepts( owner ) ) {
-			return 0;
-		}
+    key: function( owner ) {
+        // We can accept data for non-element nodes in modern browsers,
+        // but we should not, see #8335.
+        // Always return the key for a frozen object.
+        if ( !Data.accepts( owner ) ) {
+            return 0;
+        }
 
-		var descriptor = {},
-			// Check if the owner object already has a cache key
-			unlock = owner[ this.expando ];
+        var descriptor = {},
+            // Check if the owner object already has a cache key
+            unlock = owner[ this.expando ];
 
-		// If not, create one
-		if ( !unlock ) {
-			unlock = Data.uid++;
+        // If not, create one
+        if ( !unlock ) {
+            unlock = Data.uid++;
 
-			// Secure it in a non-enumerable, non-writable property
-			try {
-				descriptor[ this.expando ] = { value: unlock };
-				Object.defineProperties( owner, descriptor );
+            // Secure it in a non-enumerable, non-writable property
+            try {
+                descriptor[ this.expando ] = { value: unlock };
+                Object.defineProperties( owner, descriptor );
 
-			// Support: Android < 4
-			// Fallback to a less secure definition
-			} catch ( e ) {
-				descriptor[ this.expando ] = unlock;
-				jQuery.extend( owner, descriptor );
-			}
-		}
+            // Support: Android < 4
+            // Fallback to a less secure definition
+            } catch ( e ) {
+                descriptor[ this.expando ] = unlock;
+                jQuery.extend( owner, descriptor );
+            }
+        }
 
-		// Ensure the cache object
-		if ( !this.cache[ unlock ] ) {
-			this.cache[ unlock ] = {};
-		}
+        // Ensure the cache object
+        if ( !this.cache[ unlock ] ) {
+            this.cache[ unlock ] = {};
+        }
 
-		return unlock;
-	},
-	set: function( owner, data, value ) {
-		var prop,
-			// There may be an unlock assigned to this node,
-			// if there is no entry for this "owner", create one inline
-			// and set the unlock as though an owner entry had always existed
-			unlock = this.key( owner ),
-			cache = this.cache[ unlock ];
+        return unlock;
+    },
+    set: function( owner, data, value ) {
+        var prop,
+            // There may be an unlock assigned to this node,
+            // if there is no entry for this "owner", create one inline
+            // and set the unlock as though an owner entry had always existed
+            unlock = this.key( owner ),
+            cache = this.cache[ unlock ];
 
-		// Handle: [ owner, key, value ] args
-		if ( typeof data === "string" ) {
-			cache[ data ] = value;
+        // Handle: [ owner, key, value ] args
+        if ( typeof data === "string" ) {
+            cache[ data ] = value;
 
-		// Handle: [ owner, { properties } ] args
-		} else {
-			// Fresh assignments by object are shallow copied
-			if ( jQuery.isEmptyObject( cache ) ) {
-				jQuery.extend( this.cache[ unlock ], data );
-			// Otherwise, copy the properties one-by-one to the cache object
-			} else {
-				for ( prop in data ) {
-					cache[ prop ] = data[ prop ];
-				}
-			}
-		}
-		return cache;
-	},
-	get: function( owner, key ) {
-		// Either a valid cache is found, or will be created.
-		// New caches will be created and the unlock returned,
-		// allowing direct access to the newly created
-		// empty data object. A valid owner object must be provided.
-		var cache = this.cache[ this.key( owner ) ];
+        // Handle: [ owner, { properties } ] args
+        } else {
+            // Fresh assignments by object are shallow copied
+            if ( jQuery.isEmptyObject( cache ) ) {
+                jQuery.extend( this.cache[ unlock ], data );
+            // Otherwise, copy the properties one-by-one to the cache object
+            } else {
+                for ( prop in data ) {
+                    cache[ prop ] = data[ prop ];
+                }
+            }
+        }
+        return cache;
+    },
+    get: function( owner, key ) {
+        // Either a valid cache is found, or will be created.
+        // New caches will be created and the unlock returned,
+        // allowing direct access to the newly created
+        // empty data object. A valid owner object must be provided.
+        var cache = this.cache[ this.key( owner ) ];
 
-		return key === undefined ?
-			cache : cache[ key ];
-	},
-	access: function( owner, key, value ) {
-		// In cases where either:
-		//
-		//   1. No key was specified
-		//   2. A string key was specified, but no value provided
-		//
-		// Take the "read" path and allow the get method to determine
-		// which value to return, respectively either:
-		//
-		//   1. The entire cache object
-		//   2. The data stored at the key
-		//
-		if ( key === undefined ||
-				((key && typeof key === "string") && value === undefined) ) {
-			return this.get( owner, key );
-		}
+        return key === undefined ?
+            cache : cache[ key ];
+    },
+    access: function( owner, key, value ) {
+        // In cases where either:
+        //
+        //   1. No key was specified
+        //   2. A string key was specified, but no value provided
+        //
+        // Take the "read" path and allow the get method to determine
+        // which value to return, respectively either:
+        //
+        //   1. The entire cache object
+        //   2. The data stored at the key
+        //
+        if ( key === undefined ||
+                ((key && typeof key === "string") && value === undefined) ) {
+            return this.get( owner, key );
+        }
 
-		// [*]When the key is not a string, or both a key and value
-		// are specified, set or extend (existing objects) with either:
-		//
-		//   1. An object of properties
-		//   2. A key and value
-		//
-		this.set( owner, key, value );
+        // [*]When the key is not a string, or both a key and value
+        // are specified, set or extend (existing objects) with either:
+        //
+        //   1. An object of properties
+        //   2. A key and value
+        //
+        this.set( owner, key, value );
 
-		// Since the "set" path can have two possible entry points
-		// return the expected data based on which path was taken[*]
-		return value !== undefined ? value : key;
-	},
-	remove: function( owner, key ) {
-		var i, name, camel,
-			unlock = this.key( owner ),
-			cache = this.cache[ unlock ];
+        // Since the "set" path can have two possible entry points
+        // return the expected data based on which path was taken[*]
+        return value !== undefined ? value : key;
+    },
+    remove: function( owner, key ) {
+        var i, name, camel,
+            unlock = this.key( owner ),
+            cache = this.cache[ unlock ];
 
-		if ( key === undefined ) {
-			this.cache[ unlock ] = {};
+        if ( key === undefined ) {
+            this.cache[ unlock ] = {};
 
-		} else {
-			// Support array or space separated string of keys
-			if ( jQuery.isArray( key ) ) {
-				// If "name" is an array of keys...
-				// When data is initially created, via ("key", "val") signature,
-				// keys will be converted to camelCase.
-				// Since there is no way to tell _how_ a key was added, remove
-				// both plain key and camelCase key. #12786
-				// This will only penalize the array argument path.
-				name = key.concat( key.map( jQuery.camelCase ) );
-			} else {
-				camel = jQuery.camelCase( key );
-				// Try the string as a key before any manipulation
-				if ( key in cache ) {
-					name = [ key, camel ];
-				} else {
-					// If a key with the spaces exists, use it.
-					// Otherwise, create an array by matching non-whitespace
-					name = camel;
-					name = name in cache ?
-						[ name ] : ( name.match( core_rnotwhite ) || [] );
-				}
-			}
+        } else {
+            // Support array or space separated string of keys
+            if ( jQuery.isArray( key ) ) {
+                // If "name" is an array of keys...
+                // When data is initially created, via ("key", "val") signature,
+                // keys will be converted to camelCase.
+                // Since there is no way to tell _how_ a key was added, remove
+                // both plain key and camelCase key. #12786
+                // This will only penalize the array argument path.
+                name = key.concat( key.map( jQuery.camelCase ) );
+            } else {
+                camel = jQuery.camelCase( key );
+                // Try the string as a key before any manipulation
+                if ( key in cache ) {
+                    name = [ key, camel ];
+                } else {
+                    // If a key with the spaces exists, use it.
+                    // Otherwise, create an array by matching non-whitespace
+                    name = camel;
+                    name = name in cache ?
+                        [ name ] : ( name.match( core_rnotwhite ) || [] );
+                }
+            }
 
-			i = name.length;
-			while ( i-- ) {
-				delete cache[ name[ i ] ];
-			}
-		}
-	},
-	hasData: function( owner ) {
-		return !jQuery.isEmptyObject(
-			this.cache[ owner[ this.expando ] ] || {}
-		);
-	},
-	discard: function( owner ) {
-		if ( owner[ this.expando ] ) {
-			delete this.cache[ owner[ this.expando ] ];
-		}
-	}
+            i = name.length;
+            while ( i-- ) {
+                delete cache[ name[ i ] ];
+            }
+        }
+    },
+    hasData: function( owner ) {
+        return !jQuery.isEmptyObject(
+            this.cache[ owner[ this.expando ] ] || {}
+        );
+    },
+    discard: function( owner ) {
+        if ( owner[ this.expando ] ) {
+            delete this.cache[ owner[ this.expando ] ];
+        }
+    }
 };
 
 // These may be used throughout the jQuery core codebase
@@ -1678,817 +1678,817 @@ data_priv = new Data();
 
 
 jQuery.extend({
-	acceptData: Data.accepts,
+    acceptData: Data.accepts,
 
-	hasData: function( elem ) {
-		return data_user.hasData( elem ) || data_priv.hasData( elem );
-	},
+    hasData: function( elem ) {
+        return data_user.hasData( elem ) || data_priv.hasData( elem );
+    },
 
-	data: function( elem, name, data ) {
-		return data_user.access( elem, name, data );
-	},
+    data: function( elem, name, data ) {
+        return data_user.access( elem, name, data );
+    },
 
-	removeData: function( elem, name ) {
-		data_user.remove( elem, name );
-	},
+    removeData: function( elem, name ) {
+        data_user.remove( elem, name );
+    },
 
-	// TODO: Now that all calls to _data and _removeData have been replaced
-	// with direct calls to data_priv methods, these can be deprecated.
-	_data: function( elem, name, data ) {
-		return data_priv.access( elem, name, data );
-	},
+    // TODO: Now that all calls to _data and _removeData have been replaced
+    // with direct calls to data_priv methods, these can be deprecated.
+    _data: function( elem, name, data ) {
+        return data_priv.access( elem, name, data );
+    },
 
-	_removeData: function( elem, name ) {
-		data_priv.remove( elem, name );
-	}
+    _removeData: function( elem, name ) {
+        data_priv.remove( elem, name );
+    }
 });
 
 jQuery.fn.extend({
-	data: function( key, value ) {
-		var attrs, name,
-			elem = this[ 0 ],
-			i = 0,
-			data = null;
+    data: function( key, value ) {
+        var attrs, name,
+            elem = this[ 0 ],
+            i = 0,
+            data = null;
 
-		// Gets all values
-		if ( key === undefined ) {
-			if ( this.length ) {
-				data = data_user.get( elem );
+        // Gets all values
+        if ( key === undefined ) {
+            if ( this.length ) {
+                data = data_user.get( elem );
 
-				if ( elem.nodeType === 1 && !data_priv.get( elem, "hasDataAttrs" ) ) {
-					attrs = elem.attributes;
-					for ( ; i < attrs.length; i++ ) {
-						name = attrs[ i ].name;
+                if ( elem.nodeType === 1 && !data_priv.get( elem, "hasDataAttrs" ) ) {
+                    attrs = elem.attributes;
+                    for ( ; i < attrs.length; i++ ) {
+                        name = attrs[ i ].name;
 
-						if ( name.indexOf( "data-" ) === 0 ) {
-							name = jQuery.camelCase( name.slice(5) );
-							dataAttr( elem, name, data[ name ] );
-						}
-					}
-					data_priv.set( elem, "hasDataAttrs", true );
-				}
-			}
+                        if ( name.indexOf( "data-" ) === 0 ) {
+                            name = jQuery.camelCase( name.slice(5) );
+                            dataAttr( elem, name, data[ name ] );
+                        }
+                    }
+                    data_priv.set( elem, "hasDataAttrs", true );
+                }
+            }
 
-			return data;
-		}
+            return data;
+        }
 
-		// Sets multiple values
-		if ( typeof key === "object" ) {
-			return this.each(function() {
-				data_user.set( this, key );
-			});
-		}
+        // Sets multiple values
+        if ( typeof key === "object" ) {
+            return this.each(function() {
+                data_user.set( this, key );
+            });
+        }
 
-		return jQuery.access( this, function( value ) {
-			var data,
-				camelKey = jQuery.camelCase( key );
+        return jQuery.access( this, function( value ) {
+            var data,
+                camelKey = jQuery.camelCase( key );
 
-			// The calling jQuery object (element matches) is not empty
-			// (and therefore has an element appears at this[ 0 ]) and the
-			// `value` parameter was not undefined. An empty jQuery object
-			// will result in `undefined` for elem = this[ 0 ] which will
-			// throw an exception if an attempt to read a data cache is made.
-			if ( elem && value === undefined ) {
-				// Attempt to get data from the cache
-				// with the key as-is
-				data = data_user.get( elem, key );
-				if ( data !== undefined ) {
-					return data;
-				}
+            // The calling jQuery object (element matches) is not empty
+            // (and therefore has an element appears at this[ 0 ]) and the
+            // `value` parameter was not undefined. An empty jQuery object
+            // will result in `undefined` for elem = this[ 0 ] which will
+            // throw an exception if an attempt to read a data cache is made.
+            if ( elem && value === undefined ) {
+                // Attempt to get data from the cache
+                // with the key as-is
+                data = data_user.get( elem, key );
+                if ( data !== undefined ) {
+                    return data;
+                }
 
-				// Attempt to get data from the cache
-				// with the key camelized
-				data = data_user.get( elem, camelKey );
-				if ( data !== undefined ) {
-					return data;
-				}
+                // Attempt to get data from the cache
+                // with the key camelized
+                data = data_user.get( elem, camelKey );
+                if ( data !== undefined ) {
+                    return data;
+                }
 
-				// Attempt to "discover" the data in
-				// HTML5 custom data-* attrs
-				data = dataAttr( elem, camelKey, undefined );
-				if ( data !== undefined ) {
-					return data;
-				}
+                // Attempt to "discover" the data in
+                // HTML5 custom data-* attrs
+                data = dataAttr( elem, camelKey, undefined );
+                if ( data !== undefined ) {
+                    return data;
+                }
 
-				// We tried really hard, but the data doesn't exist.
-				return;
-			}
+                // We tried really hard, but the data doesn't exist.
+                return;
+            }
 
-			// Set the data...
-			this.each(function() {
-				// First, attempt to store a copy or reference of any
-				// data that might've been store with a camelCased key.
-				var data = data_user.get( this, camelKey );
+            // Set the data...
+            this.each(function() {
+                // First, attempt to store a copy or reference of any
+                // data that might've been store with a camelCased key.
+                var data = data_user.get( this, camelKey );
 
-				// For HTML5 data-* attribute interop, we have to
-				// store property names with dashes in a camelCase form.
-				// This might not apply to all properties...*
-				data_user.set( this, camelKey, value );
+                // For HTML5 data-* attribute interop, we have to
+                // store property names with dashes in a camelCase form.
+                // This might not apply to all properties...*
+                data_user.set( this, camelKey, value );
 
-				// *... In the case of properties that might _actually_
-				// have dashes, we need to also store a copy of that
-				// unchanged property.
-				if ( key.indexOf("-") !== -1 && data !== undefined ) {
-					data_user.set( this, key, value );
-				}
-			});
-		}, null, value, arguments.length > 1, null, true );
-	},
+                // *... In the case of properties that might _actually_
+                // have dashes, we need to also store a copy of that
+                // unchanged property.
+                if ( key.indexOf("-") !== -1 && data !== undefined ) {
+                    data_user.set( this, key, value );
+                }
+            });
+        }, null, value, arguments.length > 1, null, true );
+    },
 
-	removeData: function( key ) {
-		return this.each(function() {
-			data_user.remove( this, key );
-		});
-	}
+    removeData: function( key ) {
+        return this.each(function() {
+            data_user.remove( this, key );
+        });
+    }
 });
 
 function dataAttr( elem, key, data ) {
-	var name;
+    var name;
 
-	// If nothing was found internally, try to fetch any
-	// data from the HTML5 data-* attribute
-	if ( data === undefined && elem.nodeType === 1 ) {
-		name = "data-" + key.replace( rmultiDash, "-$1" ).toLowerCase();
-		data = elem.getAttribute( name );
+    // If nothing was found internally, try to fetch any
+    // data from the HTML5 data-* attribute
+    if ( data === undefined && elem.nodeType === 1 ) {
+        name = "data-" + key.replace( rmultiDash, "-$1" ).toLowerCase();
+        data = elem.getAttribute( name );
 
-		if ( typeof data === "string" ) {
-			try {
-				data = data === "true" ? true :
-					data === "false" ? false :
-					data === "null" ? null :
-					// Only convert to a number if it doesn't change the string
-					+data + "" === data ? +data :
-					rbrace.test( data ) ? JSON.parse( data ) :
-					data;
-			} catch( e ) {}
+        if ( typeof data === "string" ) {
+            try {
+                data = data === "true" ? true :
+                    data === "false" ? false :
+                    data === "null" ? null :
+                    // Only convert to a number if it doesn't change the string
+                    +data + "" === data ? +data :
+                    rbrace.test( data ) ? JSON.parse( data ) :
+                    data;
+            } catch( e ) {}
 
-			// Make sure we set the data so it isn't changed later
-			data_user.set( elem, key, data );
-		} else {
-			data = undefined;
-		}
-	}
-	return data;
+            // Make sure we set the data so it isn't changed later
+            data_user.set( elem, key, data );
+        } else {
+            data = undefined;
+        }
+    }
+    return data;
 }
 jQuery.extend({
-	queue: function( elem, type, data ) {
-		var queue;
+    queue: function( elem, type, data ) {
+        var queue;
 
-		if ( elem ) {
-			type = ( type || "fx" ) + "queue";
-			queue = data_priv.get( elem, type );
+        if ( elem ) {
+            type = ( type || "fx" ) + "queue";
+            queue = data_priv.get( elem, type );
 
-			// Speed up dequeue by getting out quickly if this is just a lookup
-			if ( data ) {
-				if ( !queue || jQuery.isArray( data ) ) {
-					queue = data_priv.access( elem, type, jQuery.makeArray(data) );
-				} else {
-					queue.push( data );
-				}
-			}
-			return queue || [];
-		}
-	},
+            // Speed up dequeue by getting out quickly if this is just a lookup
+            if ( data ) {
+                if ( !queue || jQuery.isArray( data ) ) {
+                    queue = data_priv.access( elem, type, jQuery.makeArray(data) );
+                } else {
+                    queue.push( data );
+                }
+            }
+            return queue || [];
+        }
+    },
 
-	dequeue: function( elem, type ) {
-		type = type || "fx";
+    dequeue: function( elem, type ) {
+        type = type || "fx";
 
-		var queue = jQuery.queue( elem, type ),
-			startLength = queue.length,
-			fn = queue.shift(),
-			hooks = jQuery._queueHooks( elem, type ),
-			next = function() {
-				jQuery.dequeue( elem, type );
-			};
+        var queue = jQuery.queue( elem, type ),
+            startLength = queue.length,
+            fn = queue.shift(),
+            hooks = jQuery._queueHooks( elem, type ),
+            next = function() {
+                jQuery.dequeue( elem, type );
+            };
 
-		// If the fx queue is dequeued, always remove the progress sentinel
-		if ( fn === "inprogress" ) {
-			fn = queue.shift();
-			startLength--;
-		}
+        // If the fx queue is dequeued, always remove the progress sentinel
+        if ( fn === "inprogress" ) {
+            fn = queue.shift();
+            startLength--;
+        }
 
-		if ( fn ) {
+        if ( fn ) {
 
-			// Add a progress sentinel to prevent the fx queue from being
-			// automatically dequeued
-			if ( type === "fx" ) {
-				queue.unshift( "inprogress" );
-			}
+            // Add a progress sentinel to prevent the fx queue from being
+            // automatically dequeued
+            if ( type === "fx" ) {
+                queue.unshift( "inprogress" );
+            }
 
-			// clear up the last queue stop function
-			delete hooks.stop;
-			fn.call( elem, next, hooks );
-		}
+            // clear up the last queue stop function
+            delete hooks.stop;
+            fn.call( elem, next, hooks );
+        }
 
-		if ( !startLength && hooks ) {
-			hooks.empty.fire();
-		}
-	},
+        if ( !startLength && hooks ) {
+            hooks.empty.fire();
+        }
+    },
 
-	// not intended for public consumption - generates a queueHooks object, or returns the current one
-	_queueHooks: function( elem, type ) {
-		var key = type + "queueHooks";
-		return data_priv.get( elem, key ) || data_priv.access( elem, key, {
-			empty: jQuery.Callbacks("once memory").add(function() {
-				data_priv.remove( elem, [ type + "queue", key ] );
-			})
-		});
-	}
+    // not intended for public consumption - generates a queueHooks object, or returns the current one
+    _queueHooks: function( elem, type ) {
+        var key = type + "queueHooks";
+        return data_priv.get( elem, key ) || data_priv.access( elem, key, {
+            empty: jQuery.Callbacks("once memory").add(function() {
+                data_priv.remove( elem, [ type + "queue", key ] );
+            })
+        });
+    }
 });
 
 jQuery.fn.extend({
-	queue: function( type, data ) {
-		var setter = 2;
+    queue: function( type, data ) {
+        var setter = 2;
 
-		if ( typeof type !== "string" ) {
-			data = type;
-			type = "fx";
-			setter--;
-		}
+        if ( typeof type !== "string" ) {
+            data = type;
+            type = "fx";
+            setter--;
+        }
 
-		if ( arguments.length < setter ) {
-			return jQuery.queue( this[0], type );
-		}
+        if ( arguments.length < setter ) {
+            return jQuery.queue( this[0], type );
+        }
 
-		return data === undefined ?
-			this :
-			this.each(function() {
-				var queue = jQuery.queue( this, type, data );
+        return data === undefined ?
+            this :
+            this.each(function() {
+                var queue = jQuery.queue( this, type, data );
 
-				// ensure a hooks for this queue
-				jQuery._queueHooks( this, type );
+                // ensure a hooks for this queue
+                jQuery._queueHooks( this, type );
 
-				if ( type === "fx" && queue[0] !== "inprogress" ) {
-					jQuery.dequeue( this, type );
-				}
-			});
-	},
-	dequeue: function( type ) {
-		return this.each(function() {
-			jQuery.dequeue( this, type );
-		});
-	},
-	// Based off of the plugin by Clint Helfers, with permission.
-	// http://blindsignals.com/index.php/2009/07/jquery-delay/
-	delay: function( time, type ) {
-		time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
-		type = type || "fx";
+                if ( type === "fx" && queue[0] !== "inprogress" ) {
+                    jQuery.dequeue( this, type );
+                }
+            });
+    },
+    dequeue: function( type ) {
+        return this.each(function() {
+            jQuery.dequeue( this, type );
+        });
+    },
+    // Based off of the plugin by Clint Helfers, with permission.
+    // http://blindsignals.com/index.php/2009/07/jquery-delay/
+    delay: function( time, type ) {
+        time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
+        type = type || "fx";
 
-		return this.queue( type, function( next, hooks ) {
-			var timeout = setTimeout( next, time );
-			hooks.stop = function() {
-				clearTimeout( timeout );
-			};
-		});
-	},
-	clearQueue: function( type ) {
-		return this.queue( type || "fx", [] );
-	},
-	// Get a promise resolved when queues of a certain type
-	// are emptied (fx is the type by default)
-	promise: function( type, obj ) {
-		var tmp,
-			count = 1,
-			defer = jQuery.Deferred(),
-			elements = this,
-			i = this.length,
-			resolve = function() {
-				if ( !( --count ) ) {
-					defer.resolveWith( elements, [ elements ] );
-				}
-			};
+        return this.queue( type, function( next, hooks ) {
+            var timeout = setTimeout( next, time );
+            hooks.stop = function() {
+                clearTimeout( timeout );
+            };
+        });
+    },
+    clearQueue: function( type ) {
+        return this.queue( type || "fx", [] );
+    },
+    // Get a promise resolved when queues of a certain type
+    // are emptied (fx is the type by default)
+    promise: function( type, obj ) {
+        var tmp,
+            count = 1,
+            defer = jQuery.Deferred(),
+            elements = this,
+            i = this.length,
+            resolve = function() {
+                if ( !( --count ) ) {
+                    defer.resolveWith( elements, [ elements ] );
+                }
+            };
 
-		if ( typeof type !== "string" ) {
-			obj = type;
-			type = undefined;
-		}
-		type = type || "fx";
+        if ( typeof type !== "string" ) {
+            obj = type;
+            type = undefined;
+        }
+        type = type || "fx";
 
-		while( i-- ) {
-			tmp = data_priv.get( elements[ i ], type + "queueHooks" );
-			if ( tmp && tmp.empty ) {
-				count++;
-				tmp.empty.add( resolve );
-			}
-		}
-		resolve();
-		return defer.promise( obj );
-	}
+        while( i-- ) {
+            tmp = data_priv.get( elements[ i ], type + "queueHooks" );
+            if ( tmp && tmp.empty ) {
+                count++;
+                tmp.empty.add( resolve );
+            }
+        }
+        resolve();
+        return defer.promise( obj );
+    }
 });
 var nodeHook, boolHook,
-	rclass = /[\t\r\n\f]/g,
-	rreturn = /\r/g,
-	rfocusable = /^(?:input|select|textarea|button)$/i;
+    rclass = /[\t\r\n\f]/g,
+    rreturn = /\r/g,
+    rfocusable = /^(?:input|select|textarea|button)$/i;
 
 jQuery.fn.extend({
-	attr: function( name, value ) {
-		return jQuery.access( this, jQuery.attr, name, value, arguments.length > 1 );
-	},
+    attr: function( name, value ) {
+        return jQuery.access( this, jQuery.attr, name, value, arguments.length > 1 );
+    },
 
-	removeAttr: function( name ) {
-		return this.each(function() {
-			jQuery.removeAttr( this, name );
-		});
-	},
+    removeAttr: function( name ) {
+        return this.each(function() {
+            jQuery.removeAttr( this, name );
+        });
+    },
 
-	prop: function( name, value ) {
-		return jQuery.access( this, jQuery.prop, name, value, arguments.length > 1 );
-	},
+    prop: function( name, value ) {
+        return jQuery.access( this, jQuery.prop, name, value, arguments.length > 1 );
+    },
 
-	removeProp: function( name ) {
-		return this.each(function() {
-			delete this[ jQuery.propFix[ name ] || name ];
-		});
-	},
+    removeProp: function( name ) {
+        return this.each(function() {
+            delete this[ jQuery.propFix[ name ] || name ];
+        });
+    },
 
-	addClass: function( value ) {
-		var classes, elem, cur, clazz, j,
-			i = 0,
-			len = this.length,
-			proceed = typeof value === "string" && value;
+    addClass: function( value ) {
+        var classes, elem, cur, clazz, j,
+            i = 0,
+            len = this.length,
+            proceed = typeof value === "string" && value;
 
-		if ( jQuery.isFunction( value ) ) {
-			return this.each(function( j ) {
-				jQuery( this ).addClass( value.call( this, j, this.className ) );
-			});
-		}
+        if ( jQuery.isFunction( value ) ) {
+            return this.each(function( j ) {
+                jQuery( this ).addClass( value.call( this, j, this.className ) );
+            });
+        }
 
-		if ( proceed ) {
-			// The disjunction here is for better compressibility (see removeClass)
-			classes = ( value || "" ).match( core_rnotwhite ) || [];
+        if ( proceed ) {
+            // The disjunction here is for better compressibility (see removeClass)
+            classes = ( value || "" ).match( core_rnotwhite ) || [];
 
-			for ( ; i < len; i++ ) {
-				elem = this[ i ];
-				cur = elem.nodeType === 1 && ( elem.className ?
-					( " " + elem.className + " " ).replace( rclass, " " ) :
-					" "
-				);
+            for ( ; i < len; i++ ) {
+                elem = this[ i ];
+                cur = elem.nodeType === 1 && ( elem.className ?
+                    ( " " + elem.className + " " ).replace( rclass, " " ) :
+                    " "
+                );
 
-				if ( cur ) {
-					j = 0;
-					while ( (clazz = classes[j++]) ) {
-						if ( cur.indexOf( " " + clazz + " " ) < 0 ) {
-							cur += clazz + " ";
-						}
-					}
-					elem.className = jQuery.trim( cur );
+                if ( cur ) {
+                    j = 0;
+                    while ( (clazz = classes[j++]) ) {
+                        if ( cur.indexOf( " " + clazz + " " ) < 0 ) {
+                            cur += clazz + " ";
+                        }
+                    }
+                    elem.className = jQuery.trim( cur );
 
-				}
-			}
-		}
+                }
+            }
+        }
 
-		return this;
-	},
+        return this;
+    },
 
-	removeClass: function( value ) {
-		var classes, elem, cur, clazz, j,
-			i = 0,
-			len = this.length,
-			proceed = arguments.length === 0 || typeof value === "string" && value;
+    removeClass: function( value ) {
+        var classes, elem, cur, clazz, j,
+            i = 0,
+            len = this.length,
+            proceed = arguments.length === 0 || typeof value === "string" && value;
 
-		if ( jQuery.isFunction( value ) ) {
-			return this.each(function( j ) {
-				jQuery( this ).removeClass( value.call( this, j, this.className ) );
-			});
-		}
-		if ( proceed ) {
-			classes = ( value || "" ).match( core_rnotwhite ) || [];
+        if ( jQuery.isFunction( value ) ) {
+            return this.each(function( j ) {
+                jQuery( this ).removeClass( value.call( this, j, this.className ) );
+            });
+        }
+        if ( proceed ) {
+            classes = ( value || "" ).match( core_rnotwhite ) || [];
 
-			for ( ; i < len; i++ ) {
-				elem = this[ i ];
-				// This expression is here for better compressibility (see addClass)
-				cur = elem.nodeType === 1 && ( elem.className ?
-					( " " + elem.className + " " ).replace( rclass, " " ) :
-					""
-				);
+            for ( ; i < len; i++ ) {
+                elem = this[ i ];
+                // This expression is here for better compressibility (see addClass)
+                cur = elem.nodeType === 1 && ( elem.className ?
+                    ( " " + elem.className + " " ).replace( rclass, " " ) :
+                    ""
+                );
 
-				if ( cur ) {
-					j = 0;
-					while ( (clazz = classes[j++]) ) {
-						// Remove *all* instances
-						while ( cur.indexOf( " " + clazz + " " ) >= 0 ) {
-							cur = cur.replace( " " + clazz + " ", " " );
-						}
-					}
-					elem.className = value ? jQuery.trim( cur ) : "";
-				}
-			}
-		}
+                if ( cur ) {
+                    j = 0;
+                    while ( (clazz = classes[j++]) ) {
+                        // Remove *all* instances
+                        while ( cur.indexOf( " " + clazz + " " ) >= 0 ) {
+                            cur = cur.replace( " " + clazz + " ", " " );
+                        }
+                    }
+                    elem.className = value ? jQuery.trim( cur ) : "";
+                }
+            }
+        }
 
-		return this;
-	},
+        return this;
+    },
 
-	toggleClass: function( value, stateVal ) {
-		var type = typeof value,
-			isBool = typeof stateVal === "boolean";
+    toggleClass: function( value, stateVal ) {
+        var type = typeof value,
+            isBool = typeof stateVal === "boolean";
 
-		if ( jQuery.isFunction( value ) ) {
-			return this.each(function( i ) {
-				jQuery( this ).toggleClass( value.call(this, i, this.className, stateVal), stateVal );
-			});
-		}
+        if ( jQuery.isFunction( value ) ) {
+            return this.each(function( i ) {
+                jQuery( this ).toggleClass( value.call(this, i, this.className, stateVal), stateVal );
+            });
+        }
 
-		return this.each(function() {
-			if ( type === "string" ) {
-				// toggle individual class names
-				var className,
-					i = 0,
-					self = jQuery( this ),
-					state = stateVal,
-					classNames = value.match( core_rnotwhite ) || [];
+        return this.each(function() {
+            if ( type === "string" ) {
+                // toggle individual class names
+                var className,
+                    i = 0,
+                    self = jQuery( this ),
+                    state = stateVal,
+                    classNames = value.match( core_rnotwhite ) || [];
 
-				while ( (className = classNames[ i++ ]) ) {
-					// check each className given, space separated list
-					state = isBool ? state : !self.hasClass( className );
-					self[ state ? "addClass" : "removeClass" ]( className );
-				}
+                while ( (className = classNames[ i++ ]) ) {
+                    // check each className given, space separated list
+                    state = isBool ? state : !self.hasClass( className );
+                    self[ state ? "addClass" : "removeClass" ]( className );
+                }
 
-			// Toggle whole class name
-			} else if ( type === core_strundefined || type === "boolean" ) {
-				if ( this.className ) {
-					// store className if set
-					data_priv.set( this, "__className__", this.className );
-				}
+            // Toggle whole class name
+            } else if ( type === core_strundefined || type === "boolean" ) {
+                if ( this.className ) {
+                    // store className if set
+                    data_priv.set( this, "__className__", this.className );
+                }
 
-				// If the element has a class name or if we're passed "false",
-				// then remove the whole classname (if there was one, the above saved it).
-				// Otherwise bring back whatever was previously saved (if anything),
-				// falling back to the empty string if nothing was stored.
-				this.className = this.className || value === false ? "" : data_priv.get( this, "__className__" ) || "";
-			}
-		});
-	},
+                // If the element has a class name or if we're passed "false",
+                // then remove the whole classname (if there was one, the above saved it).
+                // Otherwise bring back whatever was previously saved (if anything),
+                // falling back to the empty string if nothing was stored.
+                this.className = this.className || value === false ? "" : data_priv.get( this, "__className__" ) || "";
+            }
+        });
+    },
 
-	hasClass: function( selector ) {
-		var className = " " + selector + " ",
-			i = 0,
-			l = this.length;
-		for ( ; i < l; i++ ) {
-			if ( this[i].nodeType === 1 && (" " + this[i].className + " ").replace(rclass, " ").indexOf( className ) >= 0 ) {
-				return true;
-			}
-		}
+    hasClass: function( selector ) {
+        var className = " " + selector + " ",
+            i = 0,
+            l = this.length;
+        for ( ; i < l; i++ ) {
+            if ( this[i].nodeType === 1 && (" " + this[i].className + " ").replace(rclass, " ").indexOf( className ) >= 0 ) {
+                return true;
+            }
+        }
 
-		return false;
-	},
+        return false;
+    },
 
-	val: function( value ) {
-		var hooks, ret, isFunction,
-			elem = this[0];
+    val: function( value ) {
+        var hooks, ret, isFunction,
+            elem = this[0];
 
-		if ( !arguments.length ) {
-			if ( elem ) {
-				hooks = jQuery.valHooks[ elem.type ] || jQuery.valHooks[ elem.nodeName.toLowerCase() ];
+        if ( !arguments.length ) {
+            if ( elem ) {
+                hooks = jQuery.valHooks[ elem.type ] || jQuery.valHooks[ elem.nodeName.toLowerCase() ];
 
-				if ( hooks && "get" in hooks && (ret = hooks.get( elem, "value" )) !== undefined ) {
-					return ret;
-				}
+                if ( hooks && "get" in hooks && (ret = hooks.get( elem, "value" )) !== undefined ) {
+                    return ret;
+                }
 
-				ret = elem.value;
+                ret = elem.value;
 
-				return typeof ret === "string" ?
-					// handle most common string cases
-					ret.replace(rreturn, "") :
-					// handle cases where value is null/undef or number
-					ret == null ? "" : ret;
-			}
+                return typeof ret === "string" ?
+                    // handle most common string cases
+                    ret.replace(rreturn, "") :
+                    // handle cases where value is null/undef or number
+                    ret == null ? "" : ret;
+            }
 
-			return;
-		}
+            return;
+        }
 
-		isFunction = jQuery.isFunction( value );
+        isFunction = jQuery.isFunction( value );
 
-		return this.each(function( i ) {
-			var val;
+        return this.each(function( i ) {
+            var val;
 
-			if ( this.nodeType !== 1 ) {
-				return;
-			}
+            if ( this.nodeType !== 1 ) {
+                return;
+            }
 
-			if ( isFunction ) {
-				val = value.call( this, i, jQuery( this ).val() );
-			} else {
-				val = value;
-			}
+            if ( isFunction ) {
+                val = value.call( this, i, jQuery( this ).val() );
+            } else {
+                val = value;
+            }
 
-			// Treat null/undefined as ""; convert numbers to string
-			if ( val == null ) {
-				val = "";
-			} else if ( typeof val === "number" ) {
-				val += "";
-			} else if ( jQuery.isArray( val ) ) {
-				val = jQuery.map(val, function ( value ) {
-					return value == null ? "" : value + "";
-				});
-			}
+            // Treat null/undefined as ""; convert numbers to string
+            if ( val == null ) {
+                val = "";
+            } else if ( typeof val === "number" ) {
+                val += "";
+            } else if ( jQuery.isArray( val ) ) {
+                val = jQuery.map(val, function ( value ) {
+                    return value == null ? "" : value + "";
+                });
+            }
 
-			hooks = jQuery.valHooks[ this.type ] || jQuery.valHooks[ this.nodeName.toLowerCase() ];
+            hooks = jQuery.valHooks[ this.type ] || jQuery.valHooks[ this.nodeName.toLowerCase() ];
 
-			// If set returns undefined, fall back to normal setting
-			if ( !hooks || !("set" in hooks) || hooks.set( this, val, "value" ) === undefined ) {
-				this.value = val;
-			}
-		});
-	}
+            // If set returns undefined, fall back to normal setting
+            if ( !hooks || !("set" in hooks) || hooks.set( this, val, "value" ) === undefined ) {
+                this.value = val;
+            }
+        });
+    }
 });
 
 jQuery.extend({
-	valHooks: {
-		option: {
-			get: function( elem ) {
-				// attributes.value is undefined in Blackberry 4.7 but
-				// uses .value. See #6932
-				var val = elem.attributes.value;
-				return !val || val.specified ? elem.value : elem.text;
-			}
-		},
-		select: {
-			get: function( elem ) {
-				var value, option,
-					options = elem.options,
-					index = elem.selectedIndex,
-					one = elem.type === "select-one" || index < 0,
-					values = one ? null : [],
-					max = one ? index + 1 : options.length,
-					i = index < 0 ?
-						max :
-						one ? index : 0;
+    valHooks: {
+        option: {
+            get: function( elem ) {
+                // attributes.value is undefined in Blackberry 4.7 but
+                // uses .value. See #6932
+                var val = elem.attributes.value;
+                return !val || val.specified ? elem.value : elem.text;
+            }
+        },
+        select: {
+            get: function( elem ) {
+                var value, option,
+                    options = elem.options,
+                    index = elem.selectedIndex,
+                    one = elem.type === "select-one" || index < 0,
+                    values = one ? null : [],
+                    max = one ? index + 1 : options.length,
+                    i = index < 0 ?
+                        max :
+                        one ? index : 0;
 
-				// Loop through all the selected options
-				for ( ; i < max; i++ ) {
-					option = options[ i ];
+                // Loop through all the selected options
+                for ( ; i < max; i++ ) {
+                    option = options[ i ];
 
-					// IE6-9 doesn't update selected after form reset (#2551)
-					if ( ( option.selected || i === index ) &&
-							// Don't return options that are disabled or in a disabled optgroup
-							( jQuery.support.optDisabled ? !option.disabled : option.getAttribute("disabled") === null ) &&
-							( !option.parentNode.disabled || !jQuery.nodeName( option.parentNode, "optgroup" ) ) ) {
+                    // IE6-9 doesn't update selected after form reset (#2551)
+                    if ( ( option.selected || i === index ) &&
+                            // Don't return options that are disabled or in a disabled optgroup
+                            ( jQuery.support.optDisabled ? !option.disabled : option.getAttribute("disabled") === null ) &&
+                            ( !option.parentNode.disabled || !jQuery.nodeName( option.parentNode, "optgroup" ) ) ) {
 
-						// Get the specific value for the option
-						value = jQuery( option ).val();
+                        // Get the specific value for the option
+                        value = jQuery( option ).val();
 
-						// We don't need an array for one selects
-						if ( one ) {
-							return value;
-						}
+                        // We don't need an array for one selects
+                        if ( one ) {
+                            return value;
+                        }
 
-						// Multi-Selects return an array
-						values.push( value );
-					}
-				}
+                        // Multi-Selects return an array
+                        values.push( value );
+                    }
+                }
 
-				return values;
-			},
+                return values;
+            },
 
-			set: function( elem, value ) {
-				var optionSet, option,
-					options = elem.options,
-					values = jQuery.makeArray( value ),
-					i = options.length;
+            set: function( elem, value ) {
+                var optionSet, option,
+                    options = elem.options,
+                    values = jQuery.makeArray( value ),
+                    i = options.length;
 
-				while ( i-- ) {
-					option = options[ i ];
-					if ( (option.selected = jQuery.inArray( jQuery(option).val(), values ) >= 0) ) {
-						optionSet = true;
-					}
-				}
+                while ( i-- ) {
+                    option = options[ i ];
+                    if ( (option.selected = jQuery.inArray( jQuery(option).val(), values ) >= 0) ) {
+                        optionSet = true;
+                    }
+                }
 
-				// force browsers to behave consistently when non-matching value is set
-				if ( !optionSet ) {
-					elem.selectedIndex = -1;
-				}
-				return values;
-			}
-		}
-	},
+                // force browsers to behave consistently when non-matching value is set
+                if ( !optionSet ) {
+                    elem.selectedIndex = -1;
+                }
+                return values;
+            }
+        }
+    },
 
-	attr: function( elem, name, value ) {
-		var hooks, ret,
-			nType = elem.nodeType;
+    attr: function( elem, name, value ) {
+        var hooks, ret,
+            nType = elem.nodeType;
 
-		// don't get/set attributes on text, comment and attribute nodes
-		if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
-			return;
-		}
+        // don't get/set attributes on text, comment and attribute nodes
+        if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
+            return;
+        }
 
-		// Fallback to prop when attributes are not supported
-		if ( typeof elem.getAttribute === core_strundefined ) {
-			return jQuery.prop( elem, name, value );
-		}
+        // Fallback to prop when attributes are not supported
+        if ( typeof elem.getAttribute === core_strundefined ) {
+            return jQuery.prop( elem, name, value );
+        }
 
-		// All attributes are lowercase
-		// Grab necessary hook if one is defined
-		if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
-			name = name.toLowerCase();
-			hooks = jQuery.attrHooks[ name ] ||
-				( jQuery.expr.match.bool.test( name ) ? boolHook : nodeHook );
-		}
+        // All attributes are lowercase
+        // Grab necessary hook if one is defined
+        if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
+            name = name.toLowerCase();
+            hooks = jQuery.attrHooks[ name ] ||
+                ( jQuery.expr.match.bool.test( name ) ? boolHook : nodeHook );
+        }
 
-		if ( value !== undefined ) {
+        if ( value !== undefined ) {
 
-			if ( value === null ) {
-				jQuery.removeAttr( elem, name );
+            if ( value === null ) {
+                jQuery.removeAttr( elem, name );
 
-			} else if ( hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ) {
-				return ret;
+            } else if ( hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ) {
+                return ret;
 
-			} else {
-				elem.setAttribute( name, value + "" );
-				return value;
-			}
+            } else {
+                elem.setAttribute( name, value + "" );
+                return value;
+            }
 
-		} else if ( hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ) {
-			return ret;
+        } else if ( hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ) {
+            return ret;
 
-		} else {
-			ret = jQuery.find.attr( elem, name );
+        } else {
+            ret = jQuery.find.attr( elem, name );
 
-			// Non-existent attributes return null, we normalize to undefined
-			return ret == null ?
-				undefined :
-				ret;
-		}
-	},
+            // Non-existent attributes return null, we normalize to undefined
+            return ret == null ?
+                undefined :
+                ret;
+        }
+    },
 
-	removeAttr: function( elem, value ) {
-		var name, propName,
-			i = 0,
-			attrNames = value && value.match( core_rnotwhite );
+    removeAttr: function( elem, value ) {
+        var name, propName,
+            i = 0,
+            attrNames = value && value.match( core_rnotwhite );
 
-		if ( attrNames && elem.nodeType === 1 ) {
-			while ( (name = attrNames[i++]) ) {
-				propName = jQuery.propFix[ name ] || name;
+        if ( attrNames && elem.nodeType === 1 ) {
+            while ( (name = attrNames[i++]) ) {
+                propName = jQuery.propFix[ name ] || name;
 
-				// Boolean attributes get special treatment (#10870)
-				if ( jQuery.expr.match.bool.test( name ) ) {
-					// Set corresponding property to false
-					elem[ propName ] = false;
-				}
+                // Boolean attributes get special treatment (#10870)
+                if ( jQuery.expr.match.bool.test( name ) ) {
+                    // Set corresponding property to false
+                    elem[ propName ] = false;
+                }
 
-				elem.removeAttribute( name );
-			}
-		}
-	},
+                elem.removeAttribute( name );
+            }
+        }
+    },
 
-	attrHooks: {
-		type: {
-			set: function( elem, value ) {
-				if ( !jQuery.support.radioValue && value === "radio" && jQuery.nodeName(elem, "input") ) {
-					// Setting the type on a radio button after the value resets the value in IE6-9
-					// Reset value to default in case type is set after value during creation
-					var val = elem.value;
-					elem.setAttribute( "type", value );
-					if ( val ) {
-						elem.value = val;
-					}
-					return value;
-				}
-			}
-		}
-	},
+    attrHooks: {
+        type: {
+            set: function( elem, value ) {
+                if ( !jQuery.support.radioValue && value === "radio" && jQuery.nodeName(elem, "input") ) {
+                    // Setting the type on a radio button after the value resets the value in IE6-9
+                    // Reset value to default in case type is set after value during creation
+                    var val = elem.value;
+                    elem.setAttribute( "type", value );
+                    if ( val ) {
+                        elem.value = val;
+                    }
+                    return value;
+                }
+            }
+        }
+    },
 
-	propFix: {
-		"for": "htmlFor",
-		"class": "className"
-	},
+    propFix: {
+        "for": "htmlFor",
+        "class": "className"
+    },
 
-	prop: function( elem, name, value ) {
-		var ret, hooks, notxml,
-			nType = elem.nodeType;
+    prop: function( elem, name, value ) {
+        var ret, hooks, notxml,
+            nType = elem.nodeType;
 
-		// don't get/set properties on text, comment and attribute nodes
-		if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
-			return;
-		}
+        // don't get/set properties on text, comment and attribute nodes
+        if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
+            return;
+        }
 
-		notxml = nType !== 1 || !jQuery.isXMLDoc( elem );
+        notxml = nType !== 1 || !jQuery.isXMLDoc( elem );
 
-		if ( notxml ) {
-			// Fix name and attach hooks
-			name = jQuery.propFix[ name ] || name;
-			hooks = jQuery.propHooks[ name ];
-		}
+        if ( notxml ) {
+            // Fix name and attach hooks
+            name = jQuery.propFix[ name ] || name;
+            hooks = jQuery.propHooks[ name ];
+        }
 
-		if ( value !== undefined ) {
-			return hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ?
-				ret :
-				( elem[ name ] = value );
+        if ( value !== undefined ) {
+            return hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ?
+                ret :
+                ( elem[ name ] = value );
 
-		} else {
-			return hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ?
-				ret :
-				elem[ name ];
-		}
-	},
+        } else {
+            return hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ?
+                ret :
+                elem[ name ];
+        }
+    },
 
-	propHooks: {
-		tabIndex: {
-			get: function( elem ) {
-				return elem.hasAttribute( "tabindex" ) || rfocusable.test( elem.nodeName ) || elem.href ?
-					elem.tabIndex :
-					-1;
-			}
-		}
-	}
+    propHooks: {
+        tabIndex: {
+            get: function( elem ) {
+                return elem.hasAttribute( "tabindex" ) || rfocusable.test( elem.nodeName ) || elem.href ?
+                    elem.tabIndex :
+                    -1;
+            }
+        }
+    }
 });
 
 // Hooks for boolean attributes
 boolHook = {
-	set: function( elem, value, name ) {
-		if ( value === false ) {
-			// Remove boolean attributes when set to false
-			jQuery.removeAttr( elem, name );
-		} else {
-			elem.setAttribute( name, name );
-		}
-		return name;
-	}
+    set: function( elem, value, name ) {
+        if ( value === false ) {
+            // Remove boolean attributes when set to false
+            jQuery.removeAttr( elem, name );
+        } else {
+            elem.setAttribute( name, name );
+        }
+        return name;
+    }
 };
 jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( i, name ) {
-	var getter = jQuery.expr.attrHandle[ name ] || jQuery.find.attr;
+    var getter = jQuery.expr.attrHandle[ name ] || jQuery.find.attr;
 
-	jQuery.expr.attrHandle[ name ] = function( elem, name, isXML ) {
-		var fn = jQuery.expr.attrHandle[ name ],
-			ret = isXML ?
-				undefined :
-				/* jshint eqeqeq: false */
-				// Temporarily disable this handler to check existence
-				(jQuery.expr.attrHandle[ name ] = undefined) !=
-					getter( elem, name, isXML ) ?
+    jQuery.expr.attrHandle[ name ] = function( elem, name, isXML ) {
+        var fn = jQuery.expr.attrHandle[ name ],
+            ret = isXML ?
+                undefined :
+                /* jshint eqeqeq: false */
+                // Temporarily disable this handler to check existence
+                (jQuery.expr.attrHandle[ name ] = undefined) !=
+                    getter( elem, name, isXML ) ?
 
-					name.toLowerCase() :
-					null;
+                    name.toLowerCase() :
+                    null;
 
-		// Restore handler
-		jQuery.expr.attrHandle[ name ] = fn;
+        // Restore handler
+        jQuery.expr.attrHandle[ name ] = fn;
 
-		return ret;
-	};
+        return ret;
+    };
 });
 
 // Support: IE9+
 // Selectedness for an option in an optgroup can be inaccurate
 if ( !jQuery.support.optSelected ) {
-	jQuery.propHooks.selected = {
-		get: function( elem ) {
-			var parent = elem.parentNode;
-			if ( parent && parent.parentNode ) {
-				parent.parentNode.selectedIndex;
-			}
-			return null;
-		}
-	};
+    jQuery.propHooks.selected = {
+        get: function( elem ) {
+            var parent = elem.parentNode;
+            if ( parent && parent.parentNode ) {
+                parent.parentNode.selectedIndex;
+            }
+            return null;
+        }
+    };
 }
 
 jQuery.each([
-	"tabIndex",
-	"readOnly",
-	"maxLength",
-	"cellSpacing",
-	"cellPadding",
-	"rowSpan",
-	"colSpan",
-	"useMap",
-	"frameBorder",
-	"contentEditable"
+    "tabIndex",
+    "readOnly",
+    "maxLength",
+    "cellSpacing",
+    "cellPadding",
+    "rowSpan",
+    "colSpan",
+    "useMap",
+    "frameBorder",
+    "contentEditable"
 ], function() {
-	jQuery.propFix[ this.toLowerCase() ] = this;
+    jQuery.propFix[ this.toLowerCase() ] = this;
 });
 
 // Radios and checkboxes getter/setter
 jQuery.each([ "radio", "checkbox" ], function() {
-	jQuery.valHooks[ this ] = {
-		set: function( elem, value ) {
-			if ( jQuery.isArray( value ) ) {
-				return ( elem.checked = jQuery.inArray( jQuery(elem).val(), value ) >= 0 );
-			}
-		}
-	};
-	if ( !jQuery.support.checkOn ) {
-		jQuery.valHooks[ this ].get = function( elem ) {
-			// Support: Webkit
-			// "" is returned instead of "on" if a value isn't specified
-			return elem.getAttribute("value") === null ? "on" : elem.value;
-		};
-	}
+    jQuery.valHooks[ this ] = {
+        set: function( elem, value ) {
+            if ( jQuery.isArray( value ) ) {
+                return ( elem.checked = jQuery.inArray( jQuery(elem).val(), value ) >= 0 );
+            }
+        }
+    };
+    if ( !jQuery.support.checkOn ) {
+        jQuery.valHooks[ this ].get = function( elem ) {
+            // Support: Webkit
+            // "" is returned instead of "on" if a value isn't specified
+            return elem.getAttribute("value") === null ? "on" : elem.value;
+        };
+    }
 });
 var rkeyEvent = /^key/,
-	rmouseEvent = /^(?:mouse|contextmenu)|click/,
-	rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
-	rtypenamespace = /^([^.]*)(?:\.(.+)|)$/;
+    rmouseEvent = /^(?:mouse|contextmenu)|click/,
+    rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
+    rtypenamespace = /^([^.]*)(?:\.(.+)|)$/;
 
 function returnTrue() {
-	return true;
+    return true;
 }
 
 function returnFalse() {
-	return false;
+    return false;
 }
 
 function safeActiveElement() {
-	try {
-		return document.activeElement;
-	} catch ( err ) { }
+    try {
+        return document.activeElement;
+    } catch ( err ) { }
 }
 
 /*
@@ -2497,1117 +2497,1117 @@ function safeActiveElement() {
  */
 jQuery.event = {
 
-	global: {},
-
-	add: function( elem, types, handler, data, selector ) {
-
-		var handleObjIn, eventHandle, tmp,
-			events, t, handleObj,
-			special, handlers, type, namespaces, origType,
-			elemData = data_priv.get( elem );
-
-		// Don't attach events to noData or text/comment nodes (but allow plain objects)
-		if ( !elemData ) {
-			return;
-		}
-
-		// Caller can pass in an object of custom data in lieu of the handler
-		if ( handler.handler ) {
-			handleObjIn = handler;
-			handler = handleObjIn.handler;
-			selector = handleObjIn.selector;
-		}
-
-		// Make sure that the handler has a unique ID, used to find/remove it later
-		if ( !handler.guid ) {
-			handler.guid = jQuery.guid++;
-		}
-
-		// Init the element's event structure and main handler, if this is the first
-		if ( !(events = elemData.events) ) {
-			events = elemData.events = {};
-		}
-		if ( !(eventHandle = elemData.handle) ) {
-			eventHandle = elemData.handle = function( e ) {
-				// Discard the second event of a jQuery.event.trigger() and
-				// when an event is called after a page has unloaded
-				return typeof jQuery !== core_strundefined && (!e || jQuery.event.triggered !== e.type) ?
-					jQuery.event.dispatch.apply( eventHandle.elem, arguments ) :
-					undefined;
-			};
-			// Add elem as a property of the handle fn to prevent a memory leak with IE non-native events
-			eventHandle.elem = elem;
-		}
-
-		// Handle multiple events separated by a space
-		types = ( types || "" ).match( core_rnotwhite ) || [""];
-		t = types.length;
-		while ( t-- ) {
-			tmp = rtypenamespace.exec( types[t] ) || [];
-			type = origType = tmp[1];
-			namespaces = ( tmp[2] || "" ).split( "." ).sort();
-
-			// There *must* be a type, no attaching namespace-only handlers
-			if ( !type ) {
-				continue;
-			}
-
-			// If event changes its type, use the special event handlers for the changed type
-			special = jQuery.event.special[ type ] || {};
-
-			// If selector defined, determine special event api type, otherwise given type
-			type = ( selector ? special.delegateType : special.bindType ) || type;
-
-			// Update special based on newly reset type
-			special = jQuery.event.special[ type ] || {};
-
-			// handleObj is passed to all event handlers
-			handleObj = jQuery.extend({
-				type: type,
-				origType: origType,
-				data: data,
-				handler: handler,
-				guid: handler.guid,
-				selector: selector,
-				needsContext: selector && jQuery.expr.match.needsContext.test( selector ),
-				namespace: namespaces.join(".")
-			}, handleObjIn );
-
-			// Init the event handler queue if we're the first
-			if ( !(handlers = events[ type ]) ) {
-				handlers = events[ type ] = [];
-				handlers.delegateCount = 0;
-
-				// Only use addEventListener if the special events handler returns false
-				if ( !special.setup || special.setup.call( elem, data, namespaces, eventHandle ) === false ) {
-					if ( elem.addEventListener ) {
-						elem.addEventListener( type, eventHandle, false );
-					}
-				}
-			}
-
-			if ( special.add ) {
-				special.add.call( elem, handleObj );
-
-				if ( !handleObj.handler.guid ) {
-					handleObj.handler.guid = handler.guid;
-				}
-			}
-
-			// Add to the element's handler list, delegates in front
-			if ( selector ) {
-				handlers.splice( handlers.delegateCount++, 0, handleObj );
-			} else {
-				handlers.push( handleObj );
-			}
-
-			// Keep track of which events have ever been used, for event optimization
-			jQuery.event.global[ type ] = true;
-		}
-
-		// Nullify elem to prevent memory leaks in IE
-		elem = null;
-	},
-
-	// Detach an event or set of events from an element
-	remove: function( elem, types, handler, selector, mappedTypes ) {
-
-		var j, origCount, tmp,
-			events, t, handleObj,
-			special, handlers, type, namespaces, origType,
-			elemData = data_priv.hasData( elem ) && data_priv.get( elem );
-
-		if ( !elemData || !(events = elemData.events) ) {
-			return;
-		}
-
-		// Once for each type.namespace in types; type may be omitted
-		types = ( types || "" ).match( core_rnotwhite ) || [""];
-		t = types.length;
-		while ( t-- ) {
-			tmp = rtypenamespace.exec( types[t] ) || [];
-			type = origType = tmp[1];
-			namespaces = ( tmp[2] || "" ).split( "." ).sort();
-
-			// Unbind all events (on this namespace, if provided) for the element
-			if ( !type ) {
-				for ( type in events ) {
-					jQuery.event.remove( elem, type + types[ t ], handler, selector, true );
-				}
-				continue;
-			}
-
-			special = jQuery.event.special[ type ] || {};
-			type = ( selector ? special.delegateType : special.bindType ) || type;
-			handlers = events[ type ] || [];
-			tmp = tmp[2] && new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" );
-
-			// Remove matching events
-			origCount = j = handlers.length;
-			while ( j-- ) {
-				handleObj = handlers[ j ];
-
-				if ( ( mappedTypes || origType === handleObj.origType ) &&
-					( !handler || handler.guid === handleObj.guid ) &&
-					( !tmp || tmp.test( handleObj.namespace ) ) &&
-					( !selector || selector === handleObj.selector || selector === "**" && handleObj.selector ) ) {
-					handlers.splice( j, 1 );
-
-					if ( handleObj.selector ) {
-						handlers.delegateCount--;
-					}
-					if ( special.remove ) {
-						special.remove.call( elem, handleObj );
-					}
-				}
-			}
-
-			// Remove generic event handler if we removed something and no more handlers exist
-			// (avoids potential for endless recursion during removal of special event handlers)
-			if ( origCount && !handlers.length ) {
-				if ( !special.teardown || special.teardown.call( elem, namespaces, elemData.handle ) === false ) {
-					jQuery.removeEvent( elem, type, elemData.handle );
-				}
-
-				delete events[ type ];
-			}
-		}
-
-		// Remove the expando if it's no longer used
-		if ( jQuery.isEmptyObject( events ) ) {
-			delete elemData.handle;
-			data_priv.remove( elem, "events" );
-		}
-	},
-
-	trigger: function( event, data, elem, onlyHandlers ) {
-
-		var i, cur, tmp, bubbleType, ontype, handle, special,
-			eventPath = [ elem || document ],
-			type = core_hasOwn.call( event, "type" ) ? event.type : event,
-			namespaces = core_hasOwn.call( event, "namespace" ) ? event.namespace.split(".") : [];
-
-		cur = tmp = elem = elem || document;
-
-		// Don't do events on text and comment nodes
-		if ( elem.nodeType === 3 || elem.nodeType === 8 ) {
-			return;
-		}
-
-		// focus/blur morphs to focusin/out; ensure we're not firing them right now
-		if ( rfocusMorph.test( type + jQuery.event.triggered ) ) {
-			return;
-		}
-
-		if ( type.indexOf(".") >= 0 ) {
-			// Namespaced trigger; create a regexp to match event type in handle()
-			namespaces = type.split(".");
-			type = namespaces.shift();
-			namespaces.sort();
-		}
-		ontype = type.indexOf(":") < 0 && "on" + type;
-
-		// Caller can pass in a jQuery.Event object, Object, or just an event type string
-		event = event[ jQuery.expando ] ?
-			event :
-			new jQuery.Event( type, typeof event === "object" && event );
-
-		// Trigger bitmask: & 1 for native handlers; & 2 for jQuery (always true)
-		event.isTrigger = onlyHandlers ? 2 : 3;
-		event.namespace = namespaces.join(".");
-		event.namespace_re = event.namespace ?
-			new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" ) :
-			null;
-
-		// Clean up the event in case it is being reused
-		event.result = undefined;
-		if ( !event.target ) {
-			event.target = elem;
-		}
-
-		// Clone any incoming data and prepend the event, creating the handler arg list
-		data = data == null ?
-			[ event ] :
-			jQuery.makeArray( data, [ event ] );
-
-		// Allow special events to draw outside the lines
-		special = jQuery.event.special[ type ] || {};
-		if ( !onlyHandlers && special.trigger && special.trigger.apply( elem, data ) === false ) {
-			return;
-		}
-
-		// Determine event propagation path in advance, per W3C events spec (#9951)
-		// Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
-		if ( !onlyHandlers && !special.noBubble && !jQuery.isWindow( elem ) ) {
-
-			bubbleType = special.delegateType || type;
-			if ( !rfocusMorph.test( bubbleType + type ) ) {
-				cur = cur.parentNode;
-			}
-			for ( ; cur; cur = cur.parentNode ) {
-				eventPath.push( cur );
-				tmp = cur;
-			}
-
-			// Only add window if we got to document (e.g., not plain obj or detached DOM)
-			if ( tmp === (elem.ownerDocument || document) ) {
-				eventPath.push( tmp.defaultView || tmp.parentWindow || window );
-			}
-		}
-
-		// Fire handlers on the event path
-		i = 0;
-		while ( (cur = eventPath[i++]) && !event.isPropagationStopped() ) {
-
-			event.type = i > 1 ?
-				bubbleType :
-				special.bindType || type;
-
-			// jQuery handler
-			handle = ( data_priv.get( cur, "events" ) || {} )[ event.type ] && data_priv.get( cur, "handle" );
-			if ( handle ) {
-				handle.apply( cur, data );
-			}
-
-			// Native handler
-			handle = ontype && cur[ ontype ];
-			if ( handle && jQuery.acceptData( cur ) && handle.apply && handle.apply( cur, data ) === false ) {
-				event.preventDefault();
-			}
-		}
-		event.type = type;
-
-		// If nobody prevented the default action, do it now
-		if ( !onlyHandlers && !event.isDefaultPrevented() ) {
-
-			if ( (!special._default || special._default.apply( eventPath.pop(), data ) === false) &&
-				jQuery.acceptData( elem ) ) {
-
-				// Call a native DOM method on the target with the same name name as the event.
-				// Don't do default actions on window, that's where global variables be (#6170)
-				if ( ontype && jQuery.isFunction( elem[ type ] ) && !jQuery.isWindow( elem ) ) {
-
-					// Don't re-trigger an onFOO event when we call its FOO() method
-					tmp = elem[ ontype ];
-
-					if ( tmp ) {
-						elem[ ontype ] = null;
-					}
-
-					// Prevent re-triggering of the same event, since we already bubbled it above
-					jQuery.event.triggered = type;
-					elem[ type ]();
-					jQuery.event.triggered = undefined;
-
-					if ( tmp ) {
-						elem[ ontype ] = tmp;
-					}
-				}
-			}
-		}
-
-		return event.result;
-	},
-
-	dispatch: function( event ) {
-
-		// Make a writable jQuery.Event from the native event object
-		event = jQuery.event.fix( event );
-
-		var i, j, ret, matched, handleObj,
-			handlerQueue = [],
-			args = core_slice.call( arguments ),
-			handlers = ( data_priv.get( this, "events" ) || {} )[ event.type ] || [],
-			special = jQuery.event.special[ event.type ] || {};
-
-		// Use the fix-ed jQuery.Event rather than the (read-only) native event
-		args[0] = event;
-		event.delegateTarget = this;
-
-		// Call the preDispatch hook for the mapped type, and let it bail if desired
-		if ( special.preDispatch && special.preDispatch.call( this, event ) === false ) {
-			return;
-		}
-
-		// Determine handlers
-		handlerQueue = jQuery.event.handlers.call( this, event, handlers );
-
-		// Run delegates first; they may want to stop propagation beneath us
-		i = 0;
-		while ( (matched = handlerQueue[ i++ ]) && !event.isPropagationStopped() ) {
-			event.currentTarget = matched.elem;
-
-			j = 0;
-			while ( (handleObj = matched.handlers[ j++ ]) && !event.isImmediatePropagationStopped() ) {
-
-				// Triggered event must either 1) have no namespace, or
-				// 2) have namespace(s) a subset or equal to those in the bound event (both can have no namespace).
-				if ( !event.namespace_re || event.namespace_re.test( handleObj.namespace ) ) {
-
-					event.handleObj = handleObj;
-					event.data = handleObj.data;
-
-					ret = ( (jQuery.event.special[ handleObj.origType ] || {}).handle || handleObj.handler )
-							.apply( matched.elem, args );
-
-					if ( ret !== undefined ) {
-						if ( (event.result = ret) === false ) {
-							event.preventDefault();
-							event.stopPropagation();
-						}
-					}
-				}
-			}
-		}
-
-		// Call the postDispatch hook for the mapped type
-		if ( special.postDispatch ) {
-			special.postDispatch.call( this, event );
-		}
-
-		return event.result;
-	},
-
-	handlers: function( event, handlers ) {
-		var i, matches, sel, handleObj,
-			handlerQueue = [],
-			delegateCount = handlers.delegateCount,
-			cur = event.target;
-
-		// Find delegate handlers
-		// Black-hole SVG <use> instance trees (#13180)
-		// Avoid non-left-click bubbling in Firefox (#3861)
-		if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
-
-			for ( ; cur !== this; cur = cur.parentNode || this ) {
-
-				// Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
-				if ( cur.disabled !== true || event.type !== "click" ) {
-					matches = [];
-					for ( i = 0; i < delegateCount; i++ ) {
-						handleObj = handlers[ i ];
-
-						// Don't conflict with Object.prototype properties (#13203)
-						sel = handleObj.selector + " ";
-
-						if ( matches[ sel ] === undefined ) {
-							matches[ sel ] = handleObj.needsContext ?
-								jQuery( sel, this ).index( cur ) >= 0 :
-								jQuery.find( sel, this, null, [ cur ] ).length;
-						}
-						if ( matches[ sel ] ) {
-							matches.push( handleObj );
-						}
-					}
-					if ( matches.length ) {
-						handlerQueue.push({ elem: cur, handlers: matches });
-					}
-				}
-			}
-		}
-
-		// Add the remaining (directly-bound) handlers
-		if ( delegateCount < handlers.length ) {
-			handlerQueue.push({ elem: this, handlers: handlers.slice( delegateCount ) });
-		}
-
-		return handlerQueue;
-	},
-
-	// Includes some event props shared by KeyEvent and MouseEvent
-	props: "altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),
-
-	fixHooks: {},
-
-	keyHooks: {
-		props: "char charCode key keyCode".split(" "),
-		filter: function( event, original ) {
-
-			// Add which for key events
-			if ( event.which == null ) {
-				event.which = original.charCode != null ? original.charCode : original.keyCode;
-			}
-
-			return event;
-		}
-	},
-
-	mouseHooks: {
-		props: "button buttons clientX clientY offsetX offsetY pageX pageY screenX screenY toElement".split(" "),
-		filter: function( event, original ) {
-			var eventDoc, doc, body,
-				button = original.button;
-
-			// Calculate pageX/Y if missing and clientX/Y available
-			if ( event.pageX == null && original.clientX != null ) {
-				eventDoc = event.target.ownerDocument || document;
-				doc = eventDoc.documentElement;
-				body = eventDoc.body;
-
-				event.pageX = original.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 );
-				event.pageY = original.clientY + ( doc && doc.scrollTop  || body && body.scrollTop  || 0 ) - ( doc && doc.clientTop  || body && body.clientTop  || 0 );
-			}
-
-			// Add which for click: 1 === left; 2 === middle; 3 === right
-			// Note: button is not normalized, so don't use it
-			if ( !event.which && button !== undefined ) {
-				event.which = ( button & 1 ? 1 : ( button & 2 ? 3 : ( button & 4 ? 2 : 0 ) ) );
-			}
-
-			return event;
-		}
-	},
-
-	fix: function( event ) {
-		if ( event[ jQuery.expando ] ) {
-			return event;
-		}
-
-		// Create a writable copy of the event object and normalize some properties
-		var i, prop, copy,
-			type = event.type,
-			originalEvent = event,
-			fixHook = this.fixHooks[ type ];
-
-		if ( !fixHook ) {
-			this.fixHooks[ type ] = fixHook =
-				rmouseEvent.test( type ) ? this.mouseHooks :
-				rkeyEvent.test( type ) ? this.keyHooks :
-				{};
-		}
-		copy = fixHook.props ? this.props.concat( fixHook.props ) : this.props;
-
-		event = new jQuery.Event( originalEvent );
-
-		i = copy.length;
-		while ( i-- ) {
-			prop = copy[ i ];
-			event[ prop ] = originalEvent[ prop ];
-		}
-
-		// Support: Cordova 2.5 (WebKit) (#13255)
-		// All events should have a target; Cordova deviceready doesn't
-		if ( !event.target ) {
-			event.target = document;
-		}
-
-		// Support: Safari 6.0+, Chrome < 28
-		// Target should not be a text node (#504, #13143)
-		if ( event.target.nodeType === 3 ) {
-			event.target = event.target.parentNode;
-		}
-
-		return fixHook.filter? fixHook.filter( event, originalEvent ) : event;
-	},
-
-	special: {
-		load: {
-			// Prevent triggered image.load events from bubbling to window.load
-			noBubble: true
-		},
-		focus: {
-			// Fire native event if possible so blur/focus sequence is correct
-			trigger: function() {
-				if ( this !== safeActiveElement() && this.focus ) {
-					this.focus();
-					return false;
-				}
-			},
-			delegateType: "focusin"
-		},
-		blur: {
-			trigger: function() {
-				if ( this === safeActiveElement() && this.blur ) {
-					this.blur();
-					return false;
-				}
-			},
-			delegateType: "focusout"
-		},
-		click: {
-			// For checkbox, fire native event so checked state will be right
-			trigger: function() {
-				if ( this.type === "checkbox" && this.click && jQuery.nodeName( this, "input" ) ) {
-					this.click();
-					return false;
-				}
-			},
-
-			// For cross-browser consistency, don't fire native .click() on links
-			_default: function( event ) {
-				return jQuery.nodeName( event.target, "a" );
-			}
-		},
-
-		beforeunload: {
-			postDispatch: function( event ) {
-
-				// Support: Firefox 20+
-				// Firefox doesn't alert if the returnValue field is not set.
-				if ( event.result !== undefined ) {
-					event.originalEvent.returnValue = event.result;
-				}
-			}
-		}
-	},
-
-	simulate: function( type, elem, event, bubble ) {
-		// Piggyback on a donor event to simulate a different one.
-		// Fake originalEvent to avoid donor's stopPropagation, but if the
-		// simulated event prevents default then we do the same on the donor.
-		var e = jQuery.extend(
-			new jQuery.Event(),
-			event,
-			{
-				type: type,
-				isSimulated: true,
-				originalEvent: {}
-			}
-		);
-		if ( bubble ) {
-			jQuery.event.trigger( e, null, elem );
-		} else {
-			jQuery.event.dispatch.call( elem, e );
-		}
-		if ( e.isDefaultPrevented() ) {
-			event.preventDefault();
-		}
-	}
+    global: {},
+
+    add: function( elem, types, handler, data, selector ) {
+
+        var handleObjIn, eventHandle, tmp,
+            events, t, handleObj,
+            special, handlers, type, namespaces, origType,
+            elemData = data_priv.get( elem );
+
+        // Don't attach events to noData or text/comment nodes (but allow plain objects)
+        if ( !elemData ) {
+            return;
+        }
+
+        // Caller can pass in an object of custom data in lieu of the handler
+        if ( handler.handler ) {
+            handleObjIn = handler;
+            handler = handleObjIn.handler;
+            selector = handleObjIn.selector;
+        }
+
+        // Make sure that the handler has a unique ID, used to find/remove it later
+        if ( !handler.guid ) {
+            handler.guid = jQuery.guid++;
+        }
+
+        // Init the element's event structure and main handler, if this is the first
+        if ( !(events = elemData.events) ) {
+            events = elemData.events = {};
+        }
+        if ( !(eventHandle = elemData.handle) ) {
+            eventHandle = elemData.handle = function( e ) {
+                // Discard the second event of a jQuery.event.trigger() and
+                // when an event is called after a page has unloaded
+                return typeof jQuery !== core_strundefined && (!e || jQuery.event.triggered !== e.type) ?
+                    jQuery.event.dispatch.apply( eventHandle.elem, arguments ) :
+                    undefined;
+            };
+            // Add elem as a property of the handle fn to prevent a memory leak with IE non-native events
+            eventHandle.elem = elem;
+        }
+
+        // Handle multiple events separated by a space
+        types = ( types || "" ).match( core_rnotwhite ) || [""];
+        t = types.length;
+        while ( t-- ) {
+            tmp = rtypenamespace.exec( types[t] ) || [];
+            type = origType = tmp[1];
+            namespaces = ( tmp[2] || "" ).split( "." ).sort();
+
+            // There *must* be a type, no attaching namespace-only handlers
+            if ( !type ) {
+                continue;
+            }
+
+            // If event changes its type, use the special event handlers for the changed type
+            special = jQuery.event.special[ type ] || {};
+
+            // If selector defined, determine special event api type, otherwise given type
+            type = ( selector ? special.delegateType : special.bindType ) || type;
+
+            // Update special based on newly reset type
+            special = jQuery.event.special[ type ] || {};
+
+            // handleObj is passed to all event handlers
+            handleObj = jQuery.extend({
+                type: type,
+                origType: origType,
+                data: data,
+                handler: handler,
+                guid: handler.guid,
+                selector: selector,
+                needsContext: selector && jQuery.expr.match.needsContext.test( selector ),
+                namespace: namespaces.join(".")
+            }, handleObjIn );
+
+            // Init the event handler queue if we're the first
+            if ( !(handlers = events[ type ]) ) {
+                handlers = events[ type ] = [];
+                handlers.delegateCount = 0;
+
+                // Only use addEventListener if the special events handler returns false
+                if ( !special.setup || special.setup.call( elem, data, namespaces, eventHandle ) === false ) {
+                    if ( elem.addEventListener ) {
+                        elem.addEventListener( type, eventHandle, false );
+                    }
+                }
+            }
+
+            if ( special.add ) {
+                special.add.call( elem, handleObj );
+
+                if ( !handleObj.handler.guid ) {
+                    handleObj.handler.guid = handler.guid;
+                }
+            }
+
+            // Add to the element's handler list, delegates in front
+            if ( selector ) {
+                handlers.splice( handlers.delegateCount++, 0, handleObj );
+            } else {
+                handlers.push( handleObj );
+            }
+
+            // Keep track of which events have ever been used, for event optimization
+            jQuery.event.global[ type ] = true;
+        }
+
+        // Nullify elem to prevent memory leaks in IE
+        elem = null;
+    },
+
+    // Detach an event or set of events from an element
+    remove: function( elem, types, handler, selector, mappedTypes ) {
+
+        var j, origCount, tmp,
+            events, t, handleObj,
+            special, handlers, type, namespaces, origType,
+            elemData = data_priv.hasData( elem ) && data_priv.get( elem );
+
+        if ( !elemData || !(events = elemData.events) ) {
+            return;
+        }
+
+        // Once for each type.namespace in types; type may be omitted
+        types = ( types || "" ).match( core_rnotwhite ) || [""];
+        t = types.length;
+        while ( t-- ) {
+            tmp = rtypenamespace.exec( types[t] ) || [];
+            type = origType = tmp[1];
+            namespaces = ( tmp[2] || "" ).split( "." ).sort();
+
+            // Unbind all events (on this namespace, if provided) for the element
+            if ( !type ) {
+                for ( type in events ) {
+                    jQuery.event.remove( elem, type + types[ t ], handler, selector, true );
+                }
+                continue;
+            }
+
+            special = jQuery.event.special[ type ] || {};
+            type = ( selector ? special.delegateType : special.bindType ) || type;
+            handlers = events[ type ] || [];
+            tmp = tmp[2] && new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" );
+
+            // Remove matching events
+            origCount = j = handlers.length;
+            while ( j-- ) {
+                handleObj = handlers[ j ];
+
+                if ( ( mappedTypes || origType === handleObj.origType ) &&
+                    ( !handler || handler.guid === handleObj.guid ) &&
+                    ( !tmp || tmp.test( handleObj.namespace ) ) &&
+                    ( !selector || selector === handleObj.selector || selector === "**" && handleObj.selector ) ) {
+                    handlers.splice( j, 1 );
+
+                    if ( handleObj.selector ) {
+                        handlers.delegateCount--;
+                    }
+                    if ( special.remove ) {
+                        special.remove.call( elem, handleObj );
+                    }
+                }
+            }
+
+            // Remove generic event handler if we removed something and no more handlers exist
+            // (avoids potential for endless recursion during removal of special event handlers)
+            if ( origCount && !handlers.length ) {
+                if ( !special.teardown || special.teardown.call( elem, namespaces, elemData.handle ) === false ) {
+                    jQuery.removeEvent( elem, type, elemData.handle );
+                }
+
+                delete events[ type ];
+            }
+        }
+
+        // Remove the expando if it's no longer used
+        if ( jQuery.isEmptyObject( events ) ) {
+            delete elemData.handle;
+            data_priv.remove( elem, "events" );
+        }
+    },
+
+    trigger: function( event, data, elem, onlyHandlers ) {
+
+        var i, cur, tmp, bubbleType, ontype, handle, special,
+            eventPath = [ elem || document ],
+            type = core_hasOwn.call( event, "type" ) ? event.type : event,
+            namespaces = core_hasOwn.call( event, "namespace" ) ? event.namespace.split(".") : [];
+
+        cur = tmp = elem = elem || document;
+
+        // Don't do events on text and comment nodes
+        if ( elem.nodeType === 3 || elem.nodeType === 8 ) {
+            return;
+        }
+
+        // focus/blur morphs to focusin/out; ensure we're not firing them right now
+        if ( rfocusMorph.test( type + jQuery.event.triggered ) ) {
+            return;
+        }
+
+        if ( type.indexOf(".") >= 0 ) {
+            // Namespaced trigger; create a regexp to match event type in handle()
+            namespaces = type.split(".");
+            type = namespaces.shift();
+            namespaces.sort();
+        }
+        ontype = type.indexOf(":") < 0 && "on" + type;
+
+        // Caller can pass in a jQuery.Event object, Object, or just an event type string
+        event = event[ jQuery.expando ] ?
+            event :
+            new jQuery.Event( type, typeof event === "object" && event );
+
+        // Trigger bitmask: & 1 for native handlers; & 2 for jQuery (always true)
+        event.isTrigger = onlyHandlers ? 2 : 3;
+        event.namespace = namespaces.join(".");
+        event.namespace_re = event.namespace ?
+            new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" ) :
+            null;
+
+        // Clean up the event in case it is being reused
+        event.result = undefined;
+        if ( !event.target ) {
+            event.target = elem;
+        }
+
+        // Clone any incoming data and prepend the event, creating the handler arg list
+        data = data == null ?
+            [ event ] :
+            jQuery.makeArray( data, [ event ] );
+
+        // Allow special events to draw outside the lines
+        special = jQuery.event.special[ type ] || {};
+        if ( !onlyHandlers && special.trigger && special.trigger.apply( elem, data ) === false ) {
+            return;
+        }
+
+        // Determine event propagation path in advance, per W3C events spec (#9951)
+        // Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
+        if ( !onlyHandlers && !special.noBubble && !jQuery.isWindow( elem ) ) {
+
+            bubbleType = special.delegateType || type;
+            if ( !rfocusMorph.test( bubbleType + type ) ) {
+                cur = cur.parentNode;
+            }
+            for ( ; cur; cur = cur.parentNode ) {
+                eventPath.push( cur );
+                tmp = cur;
+            }
+
+            // Only add window if we got to document (e.g., not plain obj or detached DOM)
+            if ( tmp === (elem.ownerDocument || document) ) {
+                eventPath.push( tmp.defaultView || tmp.parentWindow || window );
+            }
+        }
+
+        // Fire handlers on the event path
+        i = 0;
+        while ( (cur = eventPath[i++]) && !event.isPropagationStopped() ) {
+
+            event.type = i > 1 ?
+                bubbleType :
+                special.bindType || type;
+
+            // jQuery handler
+            handle = ( data_priv.get( cur, "events" ) || {} )[ event.type ] && data_priv.get( cur, "handle" );
+            if ( handle ) {
+                handle.apply( cur, data );
+            }
+
+            // Native handler
+            handle = ontype && cur[ ontype ];
+            if ( handle && jQuery.acceptData( cur ) && handle.apply && handle.apply( cur, data ) === false ) {
+                event.preventDefault();
+            }
+        }
+        event.type = type;
+
+        // If nobody prevented the default action, do it now
+        if ( !onlyHandlers && !event.isDefaultPrevented() ) {
+
+            if ( (!special._default || special._default.apply( eventPath.pop(), data ) === false) &&
+                jQuery.acceptData( elem ) ) {
+
+                // Call a native DOM method on the target with the same name name as the event.
+                // Don't do default actions on window, that's where global variables be (#6170)
+                if ( ontype && jQuery.isFunction( elem[ type ] ) && !jQuery.isWindow( elem ) ) {
+
+                    // Don't re-trigger an onFOO event when we call its FOO() method
+                    tmp = elem[ ontype ];
+
+                    if ( tmp ) {
+                        elem[ ontype ] = null;
+                    }
+
+                    // Prevent re-triggering of the same event, since we already bubbled it above
+                    jQuery.event.triggered = type;
+                    elem[ type ]();
+                    jQuery.event.triggered = undefined;
+
+                    if ( tmp ) {
+                        elem[ ontype ] = tmp;
+                    }
+                }
+            }
+        }
+
+        return event.result;
+    },
+
+    dispatch: function( event ) {
+
+        // Make a writable jQuery.Event from the native event object
+        event = jQuery.event.fix( event );
+
+        var i, j, ret, matched, handleObj,
+            handlerQueue = [],
+            args = core_slice.call( arguments ),
+            handlers = ( data_priv.get( this, "events" ) || {} )[ event.type ] || [],
+            special = jQuery.event.special[ event.type ] || {};
+
+        // Use the fix-ed jQuery.Event rather than the (read-only) native event
+        args[0] = event;
+        event.delegateTarget = this;
+
+        // Call the preDispatch hook for the mapped type, and let it bail if desired
+        if ( special.preDispatch && special.preDispatch.call( this, event ) === false ) {
+            return;
+        }
+
+        // Determine handlers
+        handlerQueue = jQuery.event.handlers.call( this, event, handlers );
+
+        // Run delegates first; they may want to stop propagation beneath us
+        i = 0;
+        while ( (matched = handlerQueue[ i++ ]) && !event.isPropagationStopped() ) {
+            event.currentTarget = matched.elem;
+
+            j = 0;
+            while ( (handleObj = matched.handlers[ j++ ]) && !event.isImmediatePropagationStopped() ) {
+
+                // Triggered event must either 1) have no namespace, or
+                // 2) have namespace(s) a subset or equal to those in the bound event (both can have no namespace).
+                if ( !event.namespace_re || event.namespace_re.test( handleObj.namespace ) ) {
+
+                    event.handleObj = handleObj;
+                    event.data = handleObj.data;
+
+                    ret = ( (jQuery.event.special[ handleObj.origType ] || {}).handle || handleObj.handler )
+                            .apply( matched.elem, args );
+
+                    if ( ret !== undefined ) {
+                        if ( (event.result = ret) === false ) {
+                            event.preventDefault();
+                            event.stopPropagation();
+                        }
+                    }
+                }
+            }
+        }
+
+        // Call the postDispatch hook for the mapped type
+        if ( special.postDispatch ) {
+            special.postDispatch.call( this, event );
+        }
+
+        return event.result;
+    },
+
+    handlers: function( event, handlers ) {
+        var i, matches, sel, handleObj,
+            handlerQueue = [],
+            delegateCount = handlers.delegateCount,
+            cur = event.target;
+
+        // Find delegate handlers
+        // Black-hole SVG <use> instance trees (#13180)
+        // Avoid non-left-click bubbling in Firefox (#3861)
+        if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
+
+            for ( ; cur !== this; cur = cur.parentNode || this ) {
+
+                // Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
+                if ( cur.disabled !== true || event.type !== "click" ) {
+                    matches = [];
+                    for ( i = 0; i < delegateCount; i++ ) {
+                        handleObj = handlers[ i ];
+
+                        // Don't conflict with Object.prototype properties (#13203)
+                        sel = handleObj.selector + " ";
+
+                        if ( matches[ sel ] === undefined ) {
+                            matches[ sel ] = handleObj.needsContext ?
+                                jQuery( sel, this ).index( cur ) >= 0 :
+                                jQuery.find( sel, this, null, [ cur ] ).length;
+                        }
+                        if ( matches[ sel ] ) {
+                            matches.push( handleObj );
+                        }
+                    }
+                    if ( matches.length ) {
+                        handlerQueue.push({ elem: cur, handlers: matches });
+                    }
+                }
+            }
+        }
+
+        // Add the remaining (directly-bound) handlers
+        if ( delegateCount < handlers.length ) {
+            handlerQueue.push({ elem: this, handlers: handlers.slice( delegateCount ) });
+        }
+
+        return handlerQueue;
+    },
+
+    // Includes some event props shared by KeyEvent and MouseEvent
+    props: "altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),
+
+    fixHooks: {},
+
+    keyHooks: {
+        props: "char charCode key keyCode".split(" "),
+        filter: function( event, original ) {
+
+            // Add which for key events
+            if ( event.which == null ) {
+                event.which = original.charCode != null ? original.charCode : original.keyCode;
+            }
+
+            return event;
+        }
+    },
+
+    mouseHooks: {
+        props: "button buttons clientX clientY offsetX offsetY pageX pageY screenX screenY toElement".split(" "),
+        filter: function( event, original ) {
+            var eventDoc, doc, body,
+                button = original.button;
+
+            // Calculate pageX/Y if missing and clientX/Y available
+            if ( event.pageX == null && original.clientX != null ) {
+                eventDoc = event.target.ownerDocument || document;
+                doc = eventDoc.documentElement;
+                body = eventDoc.body;
+
+                event.pageX = original.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 );
+                event.pageY = original.clientY + ( doc && doc.scrollTop  || body && body.scrollTop  || 0 ) - ( doc && doc.clientTop  || body && body.clientTop  || 0 );
+            }
+
+            // Add which for click: 1 === left; 2 === middle; 3 === right
+            // Note: button is not normalized, so don't use it
+            if ( !event.which && button !== undefined ) {
+                event.which = ( button & 1 ? 1 : ( button & 2 ? 3 : ( button & 4 ? 2 : 0 ) ) );
+            }
+
+            return event;
+        }
+    },
+
+    fix: function( event ) {
+        if ( event[ jQuery.expando ] ) {
+            return event;
+        }
+
+        // Create a writable copy of the event object and normalize some properties
+        var i, prop, copy,
+            type = event.type,
+            originalEvent = event,
+            fixHook = this.fixHooks[ type ];
+
+        if ( !fixHook ) {
+            this.fixHooks[ type ] = fixHook =
+                rmouseEvent.test( type ) ? this.mouseHooks :
+                rkeyEvent.test( type ) ? this.keyHooks :
+                {};
+        }
+        copy = fixHook.props ? this.props.concat( fixHook.props ) : this.props;
+
+        event = new jQuery.Event( originalEvent );
+
+        i = copy.length;
+        while ( i-- ) {
+            prop = copy[ i ];
+            event[ prop ] = originalEvent[ prop ];
+        }
+
+        // Support: Cordova 2.5 (WebKit) (#13255)
+        // All events should have a target; Cordova deviceready doesn't
+        if ( !event.target ) {
+            event.target = document;
+        }
+
+        // Support: Safari 6.0+, Chrome < 28
+        // Target should not be a text node (#504, #13143)
+        if ( event.target.nodeType === 3 ) {
+            event.target = event.target.parentNode;
+        }
+
+        return fixHook.filter? fixHook.filter( event, originalEvent ) : event;
+    },
+
+    special: {
+        load: {
+            // Prevent triggered image.load events from bubbling to window.load
+            noBubble: true
+        },
+        focus: {
+            // Fire native event if possible so blur/focus sequence is correct
+            trigger: function() {
+                if ( this !== safeActiveElement() && this.focus ) {
+                    this.focus();
+                    return false;
+                }
+            },
+            delegateType: "focusin"
+        },
+        blur: {
+            trigger: function() {
+                if ( this === safeActiveElement() && this.blur ) {
+                    this.blur();
+                    return false;
+                }
+            },
+            delegateType: "focusout"
+        },
+        click: {
+            // For checkbox, fire native event so checked state will be right
+            trigger: function() {
+                if ( this.type === "checkbox" && this.click && jQuery.nodeName( this, "input" ) ) {
+                    this.click();
+                    return false;
+                }
+            },
+
+            // For cross-browser consistency, don't fire native .click() on links
+            _default: function( event ) {
+                return jQuery.nodeName( event.target, "a" );
+            }
+        },
+
+        beforeunload: {
+            postDispatch: function( event ) {
+
+                // Support: Firefox 20+
+                // Firefox doesn't alert if the returnValue field is not set.
+                if ( event.result !== undefined ) {
+                    event.originalEvent.returnValue = event.result;
+                }
+            }
+        }
+    },
+
+    simulate: function( type, elem, event, bubble ) {
+        // Piggyback on a donor event to simulate a different one.
+        // Fake originalEvent to avoid donor's stopPropagation, but if the
+        // simulated event prevents default then we do the same on the donor.
+        var e = jQuery.extend(
+            new jQuery.Event(),
+            event,
+            {
+                type: type,
+                isSimulated: true,
+                originalEvent: {}
+            }
+        );
+        if ( bubble ) {
+            jQuery.event.trigger( e, null, elem );
+        } else {
+            jQuery.event.dispatch.call( elem, e );
+        }
+        if ( e.isDefaultPrevented() ) {
+            event.preventDefault();
+        }
+    }
 };
 
 jQuery.removeEvent = function( elem, type, handle ) {
-	if ( elem.removeEventListener ) {
-		elem.removeEventListener( type, handle, false );
-	}
+    if ( elem.removeEventListener ) {
+        elem.removeEventListener( type, handle, false );
+    }
 };
 
 jQuery.Event = function( src, props ) {
-	// Allow instantiation without the 'new' keyword
-	if ( !(this instanceof jQuery.Event) ) {
-		return new jQuery.Event( src, props );
-	}
+    // Allow instantiation without the 'new' keyword
+    if ( !(this instanceof jQuery.Event) ) {
+        return new jQuery.Event( src, props );
+    }
 
-	// Event object
-	if ( src && src.type ) {
-		this.originalEvent = src;
-		this.type = src.type;
+    // Event object
+    if ( src && src.type ) {
+        this.originalEvent = src;
+        this.type = src.type;
 
-		// Events bubbling up the document may have been marked as prevented
-		// by a handler lower down the tree; reflect the correct value.
-		this.isDefaultPrevented = ( src.defaultPrevented ||
-			src.getPreventDefault && src.getPreventDefault() ) ? returnTrue : returnFalse;
+        // Events bubbling up the document may have been marked as prevented
+        // by a handler lower down the tree; reflect the correct value.
+        this.isDefaultPrevented = ( src.defaultPrevented ||
+            src.getPreventDefault && src.getPreventDefault() ) ? returnTrue : returnFalse;
 
-	// Event type
-	} else {
-		this.type = src;
-	}
+    // Event type
+    } else {
+        this.type = src;
+    }
 
-	// Put explicitly provided properties onto the event object
-	if ( props ) {
-		jQuery.extend( this, props );
-	}
+    // Put explicitly provided properties onto the event object
+    if ( props ) {
+        jQuery.extend( this, props );
+    }
 
-	// Create a timestamp if incoming event doesn't have one
-	this.timeStamp = src && src.timeStamp || jQuery.now();
+    // Create a timestamp if incoming event doesn't have one
+    this.timeStamp = src && src.timeStamp || jQuery.now();
 
-	// Mark it as fixed
-	this[ jQuery.expando ] = true;
+    // Mark it as fixed
+    this[ jQuery.expando ] = true;
 };
 
 // jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
 // http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
 jQuery.Event.prototype = {
-	isDefaultPrevented: returnFalse,
-	isPropagationStopped: returnFalse,
-	isImmediatePropagationStopped: returnFalse,
+    isDefaultPrevented: returnFalse,
+    isPropagationStopped: returnFalse,
+    isImmediatePropagationStopped: returnFalse,
 
-	preventDefault: function() {
-		var e = this.originalEvent;
+    preventDefault: function() {
+        var e = this.originalEvent;
 
-		this.isDefaultPrevented = returnTrue;
+        this.isDefaultPrevented = returnTrue;
 
-		if ( e && e.preventDefault ) {
-			e.preventDefault();
-		}
-	},
-	stopPropagation: function() {
-		var e = this.originalEvent;
+        if ( e && e.preventDefault ) {
+            e.preventDefault();
+        }
+    },
+    stopPropagation: function() {
+        var e = this.originalEvent;
 
-		this.isPropagationStopped = returnTrue;
+        this.isPropagationStopped = returnTrue;
 
-		if ( e && e.stopPropagation ) {
-			e.stopPropagation();
-		}
-	},
-	stopImmediatePropagation: function() {
-		this.isImmediatePropagationStopped = returnTrue;
-		this.stopPropagation();
-	}
+        if ( e && e.stopPropagation ) {
+            e.stopPropagation();
+        }
+    },
+    stopImmediatePropagation: function() {
+        this.isImmediatePropagationStopped = returnTrue;
+        this.stopPropagation();
+    }
 };
 
 // Create mouseenter/leave events using mouseover/out and event-time checks
 // Support: Chrome 15+
 jQuery.each({
-	mouseenter: "mouseover",
-	mouseleave: "mouseout"
+    mouseenter: "mouseover",
+    mouseleave: "mouseout"
 }, function( orig, fix ) {
-	jQuery.event.special[ orig ] = {
-		delegateType: fix,
-		bindType: fix,
+    jQuery.event.special[ orig ] = {
+        delegateType: fix,
+        bindType: fix,
 
-		handle: function( event ) {
-			var ret,
-				target = this,
-				related = event.relatedTarget,
-				handleObj = event.handleObj;
+        handle: function( event ) {
+            var ret,
+                target = this,
+                related = event.relatedTarget,
+                handleObj = event.handleObj;
 
-			// For mousenter/leave call the handler if related is outside the target.
-			// NB: No relatedTarget if the mouse left/entered the browser window
-			if ( !related || (related !== target && !jQuery.contains( target, related )) ) {
-				event.type = handleObj.origType;
-				ret = handleObj.handler.apply( this, arguments );
-				event.type = fix;
-			}
-			return ret;
-		}
-	};
+            // For mousenter/leave call the handler if related is outside the target.
+            // NB: No relatedTarget if the mouse left/entered the browser window
+            if ( !related || (related !== target && !jQuery.contains( target, related )) ) {
+                event.type = handleObj.origType;
+                ret = handleObj.handler.apply( this, arguments );
+                event.type = fix;
+            }
+            return ret;
+        }
+    };
 });
 
 // Create "bubbling" focus and blur events
 // Support: Firefox, Chrome, Safari
 if ( !jQuery.support.focusinBubbles ) {
-	jQuery.each({ focus: "focusin", blur: "focusout" }, function( orig, fix ) {
+    jQuery.each({ focus: "focusin", blur: "focusout" }, function( orig, fix ) {
 
-		// Attach a single capturing handler while someone wants focusin/focusout
-		var attaches = 0,
-			handler = function( event ) {
-				jQuery.event.simulate( fix, event.target, jQuery.event.fix( event ), true );
-			};
+        // Attach a single capturing handler while someone wants focusin/focusout
+        var attaches = 0,
+            handler = function( event ) {
+                jQuery.event.simulate( fix, event.target, jQuery.event.fix( event ), true );
+            };
 
-		jQuery.event.special[ fix ] = {
-			setup: function() {
-				if ( attaches++ === 0 ) {
-					document.addEventListener( orig, handler, true );
-				}
-			},
-			teardown: function() {
-				if ( --attaches === 0 ) {
-					document.removeEventListener( orig, handler, true );
-				}
-			}
-		};
-	});
+        jQuery.event.special[ fix ] = {
+            setup: function() {
+                if ( attaches++ === 0 ) {
+                    document.addEventListener( orig, handler, true );
+                }
+            },
+            teardown: function() {
+                if ( --attaches === 0 ) {
+                    document.removeEventListener( orig, handler, true );
+                }
+            }
+        };
+    });
 }
 
 jQuery.fn.extend({
 
-	on: function( types, selector, data, fn, /*INTERNAL*/ one ) {
-		var origFn, type;
+    on: function( types, selector, data, fn, /*INTERNAL*/ one ) {
+        var origFn, type;
 
-		// Types can be a map of types/handlers
-		if ( typeof types === "object" ) {
-			// ( types-Object, selector, data )
-			if ( typeof selector !== "string" ) {
-				// ( types-Object, data )
-				data = data || selector;
-				selector = undefined;
-			}
-			for ( type in types ) {
-				this.on( type, selector, data, types[ type ], one );
-			}
-			return this;
-		}
+        // Types can be a map of types/handlers
+        if ( typeof types === "object" ) {
+            // ( types-Object, selector, data )
+            if ( typeof selector !== "string" ) {
+                // ( types-Object, data )
+                data = data || selector;
+                selector = undefined;
+            }
+            for ( type in types ) {
+                this.on( type, selector, data, types[ type ], one );
+            }
+            return this;
+        }
 
-		if ( data == null && fn == null ) {
-			// ( types, fn )
-			fn = selector;
-			data = selector = undefined;
-		} else if ( fn == null ) {
-			if ( typeof selector === "string" ) {
-				// ( types, selector, fn )
-				fn = data;
-				data = undefined;
-			} else {
-				// ( types, data, fn )
-				fn = data;
-				data = selector;
-				selector = undefined;
-			}
-		}
-		if ( fn === false ) {
-			fn = returnFalse;
-		} else if ( !fn ) {
-			return this;
-		}
+        if ( data == null && fn == null ) {
+            // ( types, fn )
+            fn = selector;
+            data = selector = undefined;
+        } else if ( fn == null ) {
+            if ( typeof selector === "string" ) {
+                // ( types, selector, fn )
+                fn = data;
+                data = undefined;
+            } else {
+                // ( types, data, fn )
+                fn = data;
+                data = selector;
+                selector = undefined;
+            }
+        }
+        if ( fn === false ) {
+            fn = returnFalse;
+        } else if ( !fn ) {
+            return this;
+        }
 
-		if ( one === 1 ) {
-			origFn = fn;
-			fn = function( event ) {
-				// Can use an empty set, since event contains the info
-				jQuery().off( event );
-				return origFn.apply( this, arguments );
-			};
-			// Use same guid so caller can remove using origFn
-			fn.guid = origFn.guid || ( origFn.guid = jQuery.guid++ );
-		}
-		return this.each( function() {
-			jQuery.event.add( this, types, fn, data, selector );
-		});
-	},
-	one: function( types, selector, data, fn ) {
-		return this.on( types, selector, data, fn, 1 );
-	},
-	off: function( types, selector, fn ) {
-		var handleObj, type;
-		if ( types && types.preventDefault && types.handleObj ) {
-			// ( event )  dispatched jQuery.Event
-			handleObj = types.handleObj;
-			jQuery( types.delegateTarget ).off(
-				handleObj.namespace ? handleObj.origType + "." + handleObj.namespace : handleObj.origType,
-				handleObj.selector,
-				handleObj.handler
-			);
-			return this;
-		}
-		if ( typeof types === "object" ) {
-			// ( types-object [, selector] )
-			for ( type in types ) {
-				this.off( type, selector, types[ type ] );
-			}
-			return this;
-		}
-		if ( selector === false || typeof selector === "function" ) {
-			// ( types [, fn] )
-			fn = selector;
-			selector = undefined;
-		}
-		if ( fn === false ) {
-			fn = returnFalse;
-		}
-		return this.each(function() {
-			jQuery.event.remove( this, types, fn, selector );
-		});
-	},
+        if ( one === 1 ) {
+            origFn = fn;
+            fn = function( event ) {
+                // Can use an empty set, since event contains the info
+                jQuery().off( event );
+                return origFn.apply( this, arguments );
+            };
+            // Use same guid so caller can remove using origFn
+            fn.guid = origFn.guid || ( origFn.guid = jQuery.guid++ );
+        }
+        return this.each( function() {
+            jQuery.event.add( this, types, fn, data, selector );
+        });
+    },
+    one: function( types, selector, data, fn ) {
+        return this.on( types, selector, data, fn, 1 );
+    },
+    off: function( types, selector, fn ) {
+        var handleObj, type;
+        if ( types && types.preventDefault && types.handleObj ) {
+            // ( event )  dispatched jQuery.Event
+            handleObj = types.handleObj;
+            jQuery( types.delegateTarget ).off(
+                handleObj.namespace ? handleObj.origType + "." + handleObj.namespace : handleObj.origType,
+                handleObj.selector,
+                handleObj.handler
+            );
+            return this;
+        }
+        if ( typeof types === "object" ) {
+            // ( types-object [, selector] )
+            for ( type in types ) {
+                this.off( type, selector, types[ type ] );
+            }
+            return this;
+        }
+        if ( selector === false || typeof selector === "function" ) {
+            // ( types [, fn] )
+            fn = selector;
+            selector = undefined;
+        }
+        if ( fn === false ) {
+            fn = returnFalse;
+        }
+        return this.each(function() {
+            jQuery.event.remove( this, types, fn, selector );
+        });
+    },
 
-	trigger: function( type, data ) {
-		return this.each(function() {
-			jQuery.event.trigger( type, data, this );
-		});
-	},
-	triggerHandler: function( type, data ) {
-		var elem = this[0];
-		if ( elem ) {
-			return jQuery.event.trigger( type, data, elem, true );
-		}
-	}
+    trigger: function( type, data ) {
+        return this.each(function() {
+            jQuery.event.trigger( type, data, this );
+        });
+    },
+    triggerHandler: function( type, data ) {
+        var elem = this[0];
+        if ( elem ) {
+            return jQuery.event.trigger( type, data, elem, true );
+        }
+    }
 });
 var isSimple = /^.[^:#\[\.,]*$/,
-	rparentsprev = /^(?:parents|prev(?:Until|All))/,
-	rneedsContext = jQuery.expr.match.needsContext,
-	// methods guaranteed to produce a unique set when starting from a unique set
-	guaranteedUnique = {
-		children: true,
-		contents: true,
-		next: true,
-		prev: true
-	};
+    rparentsprev = /^(?:parents|prev(?:Until|All))/,
+    rneedsContext = jQuery.expr.match.needsContext,
+    // methods guaranteed to produce a unique set when starting from a unique set
+    guaranteedUnique = {
+        children: true,
+        contents: true,
+        next: true,
+        prev: true
+    };
 
 jQuery.fn.extend({
-	find: function( selector ) {
-		var i,
-			ret = [],
-			self = this,
-			len = self.length;
+    find: function( selector ) {
+        var i,
+            ret = [],
+            self = this,
+            len = self.length;
 
-		if ( typeof selector !== "string" ) {
-			return this.pushStack( jQuery( selector ).filter(function() {
-				for ( i = 0; i < len; i++ ) {
-					if ( jQuery.contains( self[ i ], this ) ) {
-						return true;
-					}
-				}
-			}) );
-		}
+        if ( typeof selector !== "string" ) {
+            return this.pushStack( jQuery( selector ).filter(function() {
+                for ( i = 0; i < len; i++ ) {
+                    if ( jQuery.contains( self[ i ], this ) ) {
+                        return true;
+                    }
+                }
+            }) );
+        }
 
-		for ( i = 0; i < len; i++ ) {
-			jQuery.find( selector, self[ i ], ret );
-		}
+        for ( i = 0; i < len; i++ ) {
+            jQuery.find( selector, self[ i ], ret );
+        }
 
-		// Needed because $( selector, context ) becomes $( context ).find( selector )
-		ret = this.pushStack( len > 1 ? jQuery.unique( ret ) : ret );
-		ret.selector = this.selector ? this.selector + " " + selector : selector;
-		return ret;
-	},
+        // Needed because $( selector, context ) becomes $( context ).find( selector )
+        ret = this.pushStack( len > 1 ? jQuery.unique( ret ) : ret );
+        ret.selector = this.selector ? this.selector + " " + selector : selector;
+        return ret;
+    },
 
-	has: function( target ) {
-		var targets = jQuery( target, this ),
-			l = targets.length;
+    has: function( target ) {
+        var targets = jQuery( target, this ),
+            l = targets.length;
 
-		return this.filter(function() {
-			var i = 0;
-			for ( ; i < l; i++ ) {
-				if ( jQuery.contains( this, targets[i] ) ) {
-					return true;
-				}
-			}
-		});
-	},
+        return this.filter(function() {
+            var i = 0;
+            for ( ; i < l; i++ ) {
+                if ( jQuery.contains( this, targets[i] ) ) {
+                    return true;
+                }
+            }
+        });
+    },
 
-	not: function( selector ) {
-		return this.pushStack( winnow(this, selector || [], true) );
-	},
+    not: function( selector ) {
+        return this.pushStack( winnow(this, selector || [], true) );
+    },
 
-	filter: function( selector ) {
-		return this.pushStack( winnow(this, selector || [], false) );
-	},
+    filter: function( selector ) {
+        return this.pushStack( winnow(this, selector || [], false) );
+    },
 
-	is: function( selector ) {
-		return !!winnow(
-			this,
+    is: function( selector ) {
+        return !!winnow(
+            this,
 
-			// If this is a positional/relative selector, check membership in the returned set
-			// so $("p:first").is("p:last") won't return true for a doc with two "p".
-			typeof selector === "string" && rneedsContext.test( selector ) ?
-				jQuery( selector ) :
-				selector || [],
-			false
-		).length;
-	},
+            // If this is a positional/relative selector, check membership in the returned set
+            // so $("p:first").is("p:last") won't return true for a doc with two "p".
+            typeof selector === "string" && rneedsContext.test( selector ) ?
+                jQuery( selector ) :
+                selector || [],
+            false
+        ).length;
+    },
 
-	closest: function( selectors, context ) {
-		var cur,
-			i = 0,
-			l = this.length,
-			matched = [],
-			pos = ( rneedsContext.test( selectors ) || typeof selectors !== "string" ) ?
-				jQuery( selectors, context || this.context ) :
-				0;
+    closest: function( selectors, context ) {
+        var cur,
+            i = 0,
+            l = this.length,
+            matched = [],
+            pos = ( rneedsContext.test( selectors ) || typeof selectors !== "string" ) ?
+                jQuery( selectors, context || this.context ) :
+                0;
 
-		for ( ; i < l; i++ ) {
-			for ( cur = this[i]; cur && cur !== context; cur = cur.parentNode ) {
-				// Always skip document fragments
-				if ( cur.nodeType < 11 && (pos ?
-					pos.index(cur) > -1 :
+        for ( ; i < l; i++ ) {
+            for ( cur = this[i]; cur && cur !== context; cur = cur.parentNode ) {
+                // Always skip document fragments
+                if ( cur.nodeType < 11 && (pos ?
+                    pos.index(cur) > -1 :
 
-					// Don't pass non-elements to Sizzle
-					cur.nodeType === 1 &&
-						jQuery.find.matchesSelector(cur, selectors)) ) {
+                    // Don't pass non-elements to Sizzle
+                    cur.nodeType === 1 &&
+                        jQuery.find.matchesSelector(cur, selectors)) ) {
 
-					cur = matched.push( cur );
-					break;
-				}
-			}
-		}
+                    cur = matched.push( cur );
+                    break;
+                }
+            }
+        }
 
-		return this.pushStack( matched.length > 1 ? jQuery.unique( matched ) : matched );
-	},
+        return this.pushStack( matched.length > 1 ? jQuery.unique( matched ) : matched );
+    },
 
-	// Determine the position of an element within
-	// the matched set of elements
-	index: function( elem ) {
+    // Determine the position of an element within
+    // the matched set of elements
+    index: function( elem ) {
 
-		// No argument, return index in parent
-		if ( !elem ) {
-			return ( this[ 0 ] && this[ 0 ].parentNode ) ? this.first().prevAll().length : -1;
-		}
+        // No argument, return index in parent
+        if ( !elem ) {
+            return ( this[ 0 ] && this[ 0 ].parentNode ) ? this.first().prevAll().length : -1;
+        }
 
-		// index in selector
-		if ( typeof elem === "string" ) {
-			return core_indexOf.call( jQuery( elem ), this[ 0 ] );
-		}
+        // index in selector
+        if ( typeof elem === "string" ) {
+            return core_indexOf.call( jQuery( elem ), this[ 0 ] );
+        }
 
-		// Locate the position of the desired element
-		return core_indexOf.call( this,
+        // Locate the position of the desired element
+        return core_indexOf.call( this,
 
-			// If it receives a jQuery object, the first element is used
-			elem.jquery ? elem[ 0 ] : elem
-		);
-	},
+            // If it receives a jQuery object, the first element is used
+            elem.jquery ? elem[ 0 ] : elem
+        );
+    },
 
-	add: function( selector, context ) {
-		var set = typeof selector === "string" ?
-				jQuery( selector, context ) :
-				jQuery.makeArray( selector && selector.nodeType ? [ selector ] : selector ),
-			all = jQuery.merge( this.get(), set );
+    add: function( selector, context ) {
+        var set = typeof selector === "string" ?
+                jQuery( selector, context ) :
+                jQuery.makeArray( selector && selector.nodeType ? [ selector ] : selector ),
+            all = jQuery.merge( this.get(), set );
 
-		return this.pushStack( jQuery.unique(all) );
-	},
+        return this.pushStack( jQuery.unique(all) );
+    },
 
-	addBack: function( selector ) {
-		return this.add( selector == null ?
-			this.prevObject : this.prevObject.filter(selector)
-		);
-	}
+    addBack: function( selector ) {
+        return this.add( selector == null ?
+            this.prevObject : this.prevObject.filter(selector)
+        );
+    }
 });
 
 function sibling( cur, dir ) {
-	while ( (cur = cur[dir]) && cur.nodeType !== 1 ) {}
+    while ( (cur = cur[dir]) && cur.nodeType !== 1 ) {}
 
-	return cur;
+    return cur;
 }
 
 jQuery.each({
-	parent: function( elem ) {
-		var parent = elem.parentNode;
-		return parent && parent.nodeType !== 11 ? parent : null;
-	},
-	parents: function( elem ) {
-		return jQuery.dir( elem, "parentNode" );
-	},
-	parentsUntil: function( elem, i, until ) {
-		return jQuery.dir( elem, "parentNode", until );
-	},
-	next: function( elem ) {
-		return sibling( elem, "nextSibling" );
-	},
-	prev: function( elem ) {
-		return sibling( elem, "previousSibling" );
-	},
-	nextAll: function( elem ) {
-		return jQuery.dir( elem, "nextSibling" );
-	},
-	prevAll: function( elem ) {
-		return jQuery.dir( elem, "previousSibling" );
-	},
-	nextUntil: function( elem, i, until ) {
-		return jQuery.dir( elem, "nextSibling", until );
-	},
-	prevUntil: function( elem, i, until ) {
-		return jQuery.dir( elem, "previousSibling", until );
-	},
-	siblings: function( elem ) {
-		return jQuery.sibling( ( elem.parentNode || {} ).firstChild, elem );
-	},
-	children: function( elem ) {
-		return jQuery.sibling( elem.firstChild );
-	},
-	contents: function( elem ) {
-		return elem.contentDocument || jQuery.merge( [], elem.childNodes );
-	}
+    parent: function( elem ) {
+        var parent = elem.parentNode;
+        return parent && parent.nodeType !== 11 ? parent : null;
+    },
+    parents: function( elem ) {
+        return jQuery.dir( elem, "parentNode" );
+    },
+    parentsUntil: function( elem, i, until ) {
+        return jQuery.dir( elem, "parentNode", until );
+    },
+    next: function( elem ) {
+        return sibling( elem, "nextSibling" );
+    },
+    prev: function( elem ) {
+        return sibling( elem, "previousSibling" );
+    },
+    nextAll: function( elem ) {
+        return jQuery.dir( elem, "nextSibling" );
+    },
+    prevAll: function( elem ) {
+        return jQuery.dir( elem, "previousSibling" );
+    },
+    nextUntil: function( elem, i, until ) {
+        return jQuery.dir( elem, "nextSibling", until );
+    },
+    prevUntil: function( elem, i, until ) {
+        return jQuery.dir( elem, "previousSibling", until );
+    },
+    siblings: function( elem ) {
+        return jQuery.sibling( ( elem.parentNode || {} ).firstChild, elem );
+    },
+    children: function( elem ) {
+        return jQuery.sibling( elem.firstChild );
+    },
+    contents: function( elem ) {
+        return elem.contentDocument || jQuery.merge( [], elem.childNodes );
+    }
 }, function( name, fn ) {
-	jQuery.fn[ name ] = function( until, selector ) {
-		var matched = jQuery.map( this, fn, until );
+    jQuery.fn[ name ] = function( until, selector ) {
+        var matched = jQuery.map( this, fn, until );
 
-		if ( name.slice( -5 ) !== "Until" ) {
-			selector = until;
-		}
+        if ( name.slice( -5 ) !== "Until" ) {
+            selector = until;
+        }
 
-		if ( selector && typeof selector === "string" ) {
-			matched = jQuery.filter( selector, matched );
-		}
+        if ( selector && typeof selector === "string" ) {
+            matched = jQuery.filter( selector, matched );
+        }
 
-		if ( this.length > 1 ) {
-			// Remove duplicates
-			if ( !guaranteedUnique[ name ] ) {
-				jQuery.unique( matched );
-			}
+        if ( this.length > 1 ) {
+            // Remove duplicates
+            if ( !guaranteedUnique[ name ] ) {
+                jQuery.unique( matched );
+            }
 
-			// Reverse order for parents* and prev-derivatives
-			if ( rparentsprev.test( name ) ) {
-				matched.reverse();
-			}
-		}
+            // Reverse order for parents* and prev-derivatives
+            if ( rparentsprev.test( name ) ) {
+                matched.reverse();
+            }
+        }
 
-		return this.pushStack( matched );
-	};
+        return this.pushStack( matched );
+    };
 });
 
 jQuery.extend({
-	filter: function( expr, elems, not ) {
-		var elem = elems[ 0 ];
+    filter: function( expr, elems, not ) {
+        var elem = elems[ 0 ];
 
-		if ( not ) {
-			expr = ":not(" + expr + ")";
-		}
+        if ( not ) {
+            expr = ":not(" + expr + ")";
+        }
 
-		return elems.length === 1 && elem.nodeType === 1 ?
-			jQuery.find.matchesSelector( elem, expr ) ? [ elem ] : [] :
-			jQuery.find.matches( expr, jQuery.grep( elems, function( elem ) {
-				return elem.nodeType === 1;
-			}));
-	},
+        return elems.length === 1 && elem.nodeType === 1 ?
+            jQuery.find.matchesSelector( elem, expr ) ? [ elem ] : [] :
+            jQuery.find.matches( expr, jQuery.grep( elems, function( elem ) {
+                return elem.nodeType === 1;
+            }));
+    },
 
-	dir: function( elem, dir, until ) {
-		var matched = [],
-			truncate = until !== undefined;
+    dir: function( elem, dir, until ) {
+        var matched = [],
+            truncate = until !== undefined;
 
-		while ( (elem = elem[ dir ]) && elem.nodeType !== 9 ) {
-			if ( elem.nodeType === 1 ) {
-				if ( truncate && jQuery( elem ).is( until ) ) {
-					break;
-				}
-				matched.push( elem );
-			}
-		}
-		return matched;
-	},
+        while ( (elem = elem[ dir ]) && elem.nodeType !== 9 ) {
+            if ( elem.nodeType === 1 ) {
+                if ( truncate && jQuery( elem ).is( until ) ) {
+                    break;
+                }
+                matched.push( elem );
+            }
+        }
+        return matched;
+    },
 
-	sibling: function( n, elem ) {
-		var matched = [];
+    sibling: function( n, elem ) {
+        var matched = [];
 
-		for ( ; n; n = n.nextSibling ) {
-			if ( n.nodeType === 1 && n !== elem ) {
-				matched.push( n );
-			}
-		}
+        for ( ; n; n = n.nextSibling ) {
+            if ( n.nodeType === 1 && n !== elem ) {
+                matched.push( n );
+            }
+        }
 
-		return matched;
-	}
+        return matched;
+    }
 });
 
 // Implement the identical functionality for filter and not
 function winnow( elements, qualifier, not ) {
-	if ( jQuery.isFunction( qualifier ) ) {
-		return jQuery.grep( elements, function( elem, i ) {
-			/* jshint -W018 */
-			return !!qualifier.call( elem, i, elem ) !== not;
-		});
+    if ( jQuery.isFunction( qualifier ) ) {
+        return jQuery.grep( elements, function( elem, i ) {
+            /* jshint -W018 */
+            return !!qualifier.call( elem, i, elem ) !== not;
+        });
 
-	}
+    }
 
-	if ( qualifier.nodeType ) {
-		return jQuery.grep( elements, function( elem ) {
-			return ( elem === qualifier ) !== not;
-		});
+    if ( qualifier.nodeType ) {
+        return jQuery.grep( elements, function( elem ) {
+            return ( elem === qualifier ) !== not;
+        });
 
-	}
+    }
 
-	if ( typeof qualifier === "string" ) {
-		if ( isSimple.test( qualifier ) ) {
-			return jQuery.filter( qualifier, elements, not );
-		}
+    if ( typeof qualifier === "string" ) {
+        if ( isSimple.test( qualifier ) ) {
+            return jQuery.filter( qualifier, elements, not );
+        }
 
-		qualifier = jQuery.filter( qualifier, elements );
-	}
+        qualifier = jQuery.filter( qualifier, elements );
+    }
 
-	return jQuery.grep( elements, function( elem ) {
-		return ( core_indexOf.call( qualifier, elem ) >= 0 ) !== not;
-	});
+    return jQuery.grep( elements, function( elem ) {
+        return ( core_indexOf.call( qualifier, elem ) >= 0 ) !== not;
+    });
 }
 var rxhtmlTag = /<(?!area|br|col|embed|hr|img|input|link|meta|param)(([\w:]+)[^>]*)\/>/gi,
-	rtagName = /<([\w:]+)/,
-	rhtml = /<|&#?\w+;/,
-	rnoInnerhtml = /<(?:script|style|link)/i,
-	manipulation_rcheckableType = /^(?:checkbox|radio)$/i,
-	// checked="checked" or checked
-	rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
-	rscriptType = /^$|\/(?:java|ecma)script/i,
-	rscriptTypeMasked = /^true\/(.*)/,
-	rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
+    rtagName = /<([\w:]+)/,
+    rhtml = /<|&#?\w+;/,
+    rnoInnerhtml = /<(?:script|style|link)/i,
+    manipulation_rcheckableType = /^(?:checkbox|radio)$/i,
+    // checked="checked" or checked
+    rchecked = /checked\s*(?:[^=]|=\s*.checked.)/i,
+    rscriptType = /^$|\/(?:java|ecma)script/i,
+    rscriptTypeMasked = /^true\/(.*)/,
+    rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
 
-	// We have to close these tags to support XHTML (#13200)
-	wrapMap = {
+    // We have to close these tags to support XHTML (#13200)
+    wrapMap = {
 
-		// Support: IE 9
-		option: [ 1, "<select multiple='multiple'>", "</select>" ],
+        // Support: IE 9
+        option: [ 1, "<select multiple='multiple'>", "</select>" ],
 
-		thead: [ 1, "<table>", "</table>" ],
-		col: [ 2, "<table><colgroup>", "</colgroup></table>" ],
-		tr: [ 2, "<table><tbody>", "</tbody></table>" ],
-		td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
+        thead: [ 1, "<table>", "</table>" ],
+        col: [ 2, "<table><colgroup>", "</colgroup></table>" ],
+        tr: [ 2, "<table><tbody>", "</tbody></table>" ],
+        td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
 
-		_default: [ 0, "", "" ]
-	};
+        _default: [ 0, "", "" ]
+    };
 
 // Support: IE 9
 wrapMap.optgroup = wrapMap.option;
@@ -3616,1274 +3616,1510 @@ wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.the
 wrapMap.th = wrapMap.td;
 
 jQuery.fn.extend({
-	text: function( value ) {
-		return jQuery.access( this, function( value ) {
-			return value === undefined ?
-				jQuery.text( this ) :
-				this.empty().append( ( this[ 0 ] && this[ 0 ].ownerDocument || document ).createTextNode( value ) );
-		}, null, value, arguments.length );
-	},
+    text: function( value ) {
+        return jQuery.access( this, function( value ) {
+            return value === undefined ?
+                jQuery.text( this ) :
+                this.empty().append( ( this[ 0 ] && this[ 0 ].ownerDocument || document ).createTextNode( value ) );
+        }, null, value, arguments.length );
+    },
 
-	append: function() {
-		return this.domManip( arguments, function( elem ) {
-			if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
-				var target = manipulationTarget( this, elem );
-				target.appendChild( elem );
-			}
-		});
-	},
+    append: function() {
+        return this.domManip( arguments, function( elem ) {
+            if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
+                var target = manipulationTarget( this, elem );
+                target.appendChild( elem );
+            }
+        });
+    },
 
-	prepend: function() {
-		return this.domManip( arguments, function( elem ) {
-			if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
-				var target = manipulationTarget( this, elem );
-				target.insertBefore( elem, target.firstChild );
-			}
-		});
-	},
+    prepend: function() {
+        return this.domManip( arguments, function( elem ) {
+            if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
+                var target = manipulationTarget( this, elem );
+                target.insertBefore( elem, target.firstChild );
+            }
+        });
+    },
 
-	before: function() {
-		return this.domManip( arguments, function( elem ) {
-			if ( this.parentNode ) {
-				this.parentNode.insertBefore( elem, this );
-			}
-		});
-	},
+    before: function() {
+        return this.domManip( arguments, function( elem ) {
+            if ( this.parentNode ) {
+                this.parentNode.insertBefore( elem, this );
+            }
+        });
+    },
 
-	after: function() {
-		return this.domManip( arguments, function( elem ) {
-			if ( this.parentNode ) {
-				this.parentNode.insertBefore( elem, this.nextSibling );
-			}
-		});
-	},
+    after: function() {
+        return this.domManip( arguments, function( elem ) {
+            if ( this.parentNode ) {
+                this.parentNode.insertBefore( elem, this.nextSibling );
+            }
+        });
+    },
 
-	// keepData is for internal use only--do not document
-	remove: function( selector, keepData ) {
-		var elem,
-			elems = selector ? jQuery.filter( selector, this ) : this,
-			i = 0;
+    // keepData is for internal use only--do not document
+    remove: function( selector, keepData ) {
+        var elem,
+            elems = selector ? jQuery.filter( selector, this ) : this,
+            i = 0;
 
-		for ( ; (elem = elems[i]) != null; i++ ) {
-			if ( !keepData && elem.nodeType === 1 ) {
-				jQuery.cleanData( getAll( elem ) );
-			}
+        for ( ; (elem = elems[i]) != null; i++ ) {
+            if ( !keepData && elem.nodeType === 1 ) {
+                jQuery.cleanData( getAll( elem ) );
+            }
 
-			if ( elem.parentNode ) {
-				if ( keepData && jQuery.contains( elem.ownerDocument, elem ) ) {
-					setGlobalEval( getAll( elem, "script" ) );
-				}
-				elem.parentNode.removeChild( elem );
-			}
-		}
+            if ( elem.parentNode ) {
+                if ( keepData && jQuery.contains( elem.ownerDocument, elem ) ) {
+                    setGlobalEval( getAll( elem, "script" ) );
+                }
+                elem.parentNode.removeChild( elem );
+            }
+        }
 
-		return this;
-	},
+        return this;
+    },
 
-	empty: function() {
-		var elem,
-			i = 0;
+    empty: function() {
+        var elem,
+            i = 0;
 
-		for ( ; (elem = this[i]) != null; i++ ) {
-			if ( elem.nodeType === 1 ) {
+        for ( ; (elem = this[i]) != null; i++ ) {
+            if ( elem.nodeType === 1 ) {
 
-				// Prevent memory leaks
-				jQuery.cleanData( getAll( elem, false ) );
+                // Prevent memory leaks
+                jQuery.cleanData( getAll( elem, false ) );
 
-				// Remove any remaining nodes
-				elem.textContent = "";
-			}
-		}
+                // Remove any remaining nodes
+                elem.textContent = "";
+            }
+        }
 
-		return this;
-	},
+        return this;
+    },
 
-	clone: function( dataAndEvents, deepDataAndEvents ) {
-		dataAndEvents = dataAndEvents == null ? false : dataAndEvents;
-		deepDataAndEvents = deepDataAndEvents == null ? dataAndEvents : deepDataAndEvents;
+    clone: function( dataAndEvents, deepDataAndEvents ) {
+        dataAndEvents = dataAndEvents == null ? false : dataAndEvents;
+        deepDataAndEvents = deepDataAndEvents == null ? dataAndEvents : deepDataAndEvents;
 
-		return this.map( function () {
-			return jQuery.clone( this, dataAndEvents, deepDataAndEvents );
-		});
-	},
+        return this.map( function () {
+            return jQuery.clone( this, dataAndEvents, deepDataAndEvents );
+        });
+    },
 
-	html: function( value ) {
-		return jQuery.access( this, function( value ) {
-			var elem = this[ 0 ] || {},
-				i = 0,
-				l = this.length;
+    html: function( value ) {
+        return jQuery.access( this, function( value ) {
+            var elem = this[ 0 ] || {},
+                i = 0,
+                l = this.length;
 
-			if ( value === undefined && elem.nodeType === 1 ) {
-				return elem.innerHTML;
-			}
+            if ( value === undefined && elem.nodeType === 1 ) {
+                return elem.innerHTML;
+            }
 
-			// See if we can take a shortcut and just use innerHTML
-			if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&
-				!wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) {
+            // See if we can take a shortcut and just use innerHTML
+            if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&
+                !wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) {
 
-				value = value.replace( rxhtmlTag, "<$1></$2>" );
+                value = value.replace( rxhtmlTag, "<$1></$2>" );
 
-				try {
-					for ( ; i < l; i++ ) {
-						elem = this[ i ] || {};
+                try {
+                    for ( ; i < l; i++ ) {
+                        elem = this[ i ] || {};
 
-						// Remove element nodes and prevent memory leaks
-						if ( elem.nodeType === 1 ) {
-							jQuery.cleanData( getAll( elem, false ) );
-							elem.innerHTML = value;
-						}
-					}
+                        // Remove element nodes and prevent memory leaks
+                        if ( elem.nodeType === 1 ) {
+                            jQuery.cleanData( getAll( elem, false ) );
+                            elem.innerHTML = value;
+                        }
+                    }
 
-					elem = 0;
+                    elem = 0;
 
-				// If using innerHTML throws an exception, use the fallback method
-				} catch( e ) {}
-			}
+                // If using innerHTML throws an exception, use the fallback method
+                } catch( e ) {}
+            }
 
-			if ( elem ) {
-				this.empty().append( value );
-			}
-		}, null, value, arguments.length );
-	},
+            if ( elem ) {
+                this.empty().append( value );
+            }
+        }, null, value, arguments.length );
+    },
 
-	replaceWith: function() {
-		var
-			// Snapshot the DOM in case .domManip sweeps something relevant into its fragment
-			args = jQuery.map( this, function( elem ) {
-				return [ elem.nextSibling, elem.parentNode ];
-			}),
-			i = 0;
+    replaceWith: function() {
+        var
+            // Snapshot the DOM in case .domManip sweeps something relevant into its fragment
+            args = jQuery.map( this, function( elem ) {
+                return [ elem.nextSibling, elem.parentNode ];
+            }),
+            i = 0;
 
-		// Make the changes, replacing each context element with the new content
-		this.domManip( arguments, function( elem ) {
-			var next = args[ i++ ],
-				parent = args[ i++ ];
+        // Make the changes, replacing each context element with the new content
+        this.domManip( arguments, function( elem ) {
+            var next = args[ i++ ],
+                parent = args[ i++ ];
 
-			if ( parent ) {
-				// Don't use the snapshot next if it has moved (#13810)
-				if ( next && next.parentNode !== parent ) {
-					next = this.nextSibling;
-				}
-				jQuery( this ).remove();
-				parent.insertBefore( elem, next );
-			}
-		// Allow new content to include elements from the context set
-		}, true );
+            if ( parent ) {
+                // Don't use the snapshot next if it has moved (#13810)
+                if ( next && next.parentNode !== parent ) {
+                    next = this.nextSibling;
+                }
+                jQuery( this ).remove();
+                parent.insertBefore( elem, next );
+            }
+        // Allow new content to include elements from the context set
+        }, true );
 
-		// Force removal if there was no new content (e.g., from empty arguments)
-		return i ? this : this.remove();
-	},
+        // Force removal if there was no new content (e.g., from empty arguments)
+        return i ? this : this.remove();
+    },
 
-	detach: function( selector ) {
-		return this.remove( selector, true );
-	},
+    detach: function( selector ) {
+        return this.remove( selector, true );
+    },
 
-	domManip: function( args, callback, allowIntersection ) {
+    domManip: function( args, callback, allowIntersection ) {
 
-		// Flatten any nested arrays
-		args = core_concat.apply( [], args );
+        // Flatten any nested arrays
+        args = core_concat.apply( [], args );
 
-		var fragment, first, scripts, hasScripts, node, doc,
-			i = 0,
-			l = this.length,
-			set = this,
-			iNoClone = l - 1,
-			value = args[ 0 ],
-			isFunction = jQuery.isFunction( value );
+        var fragment, first, scripts, hasScripts, node, doc,
+            i = 0,
+            l = this.length,
+            set = this,
+            iNoClone = l - 1,
+            value = args[ 0 ],
+            isFunction = jQuery.isFunction( value );
 
-		// We can't cloneNode fragments that contain checked, in WebKit
-		if ( isFunction || !( l <= 1 || typeof value !== "string" || jQuery.support.checkClone || !rchecked.test( value ) ) ) {
-			return this.each(function( index ) {
-				var self = set.eq( index );
-				if ( isFunction ) {
-					args[ 0 ] = value.call( this, index, self.html() );
-				}
-				self.domManip( args, callback, allowIntersection );
-			});
-		}
+        // We can't cloneNode fragments that contain checked, in WebKit
+        if ( isFunction || !( l <= 1 || typeof value !== "string" || jQuery.support.checkClone || !rchecked.test( value ) ) ) {
+            return this.each(function( index ) {
+                var self = set.eq( index );
+                if ( isFunction ) {
+                    args[ 0 ] = value.call( this, index, self.html() );
+                }
+                self.domManip( args, callback, allowIntersection );
+            });
+        }
 
-		if ( l ) {
-			fragment = jQuery.buildFragment( args, this[ 0 ].ownerDocument, false, !allowIntersection && this );
-			first = fragment.firstChild;
+        if ( l ) {
+            fragment = jQuery.buildFragment( args, this[ 0 ].ownerDocument, false, !allowIntersection && this );
+            first = fragment.firstChild;
 
-			if ( fragment.childNodes.length === 1 ) {
-				fragment = first;
-			}
+            if ( fragment.childNodes.length === 1 ) {
+                fragment = first;
+            }
 
-			if ( first ) {
-				scripts = jQuery.map( getAll( fragment, "script" ), disableScript );
-				hasScripts = scripts.length;
+            if ( first ) {
+                scripts = jQuery.map( getAll( fragment, "script" ), disableScript );
+                hasScripts = scripts.length;
 
-				// Use the original fragment for the last item instead of the first because it can end up
-				// being emptied incorrectly in certain situations (#8070).
-				for ( ; i < l; i++ ) {
-					node = fragment;
+                // Use the original fragment for the last item instead of the first because it can end up
+                // being emptied incorrectly in certain situations (#8070).
+                for ( ; i < l; i++ ) {
+                    node = fragment;
 
-					if ( i !== iNoClone ) {
-						node = jQuery.clone( node, true, true );
+                    if ( i !== iNoClone ) {
+                        node = jQuery.clone( node, true, true );
 
-						// Keep references to cloned scripts for later restoration
-						if ( hasScripts ) {
-							// Support: QtWebKit
-							// jQuery.merge because core_push.apply(_, arraylike) throws
-							jQuery.merge( scripts, getAll( node, "script" ) );
-						}
-					}
+                        // Keep references to cloned scripts for later restoration
+                        if ( hasScripts ) {
+                            // Support: QtWebKit
+                            // jQuery.merge because core_push.apply(_, arraylike) throws
+                            jQuery.merge( scripts, getAll( node, "script" ) );
+                        }
+                    }
 
-					callback.call( this[ i ], node, i );
-				}
+                    callback.call( this[ i ], node, i );
+                }
 
-				if ( hasScripts ) {
-					doc = scripts[ scripts.length - 1 ].ownerDocument;
+                if ( hasScripts ) {
+                    doc = scripts[ scripts.length - 1 ].ownerDocument;
 
-					// Reenable scripts
-					jQuery.map( scripts, restoreScript );
+                    // Reenable scripts
+                    jQuery.map( scripts, restoreScript );
 
-					// Evaluate executable scripts on first document insertion
-					for ( i = 0; i < hasScripts; i++ ) {
-						node = scripts[ i ];
-						if ( rscriptType.test( node.type || "" ) &&
-							!data_priv.access( node, "globalEval" ) && jQuery.contains( doc, node ) ) {
+                    // Evaluate executable scripts on first document insertion
+                    for ( i = 0; i < hasScripts; i++ ) {
+                        node = scripts[ i ];
+                        if ( rscriptType.test( node.type || "" ) &&
+                            !data_priv.access( node, "globalEval" ) && jQuery.contains( doc, node ) ) {
 
-							if ( node.src ) {
-								// Hope ajax is available...
-								jQuery._evalUrl( node.src );
-							} else {
-								jQuery.globalEval( node.textContent.replace( rcleanScript, "" ) );
-							}
-						}
-					}
-				}
-			}
-		}
+                            if ( node.src ) {
+                                // Hope ajax is available...
+                                jQuery._evalUrl( node.src );
+                            } else {
+                                jQuery.globalEval( node.textContent.replace( rcleanScript, "" ) );
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-		return this;
-	}
+        return this;
+    }
 });
 
 jQuery.each({
-	appendTo: "append",
-	prependTo: "prepend",
-	insertBefore: "before",
-	insertAfter: "after",
-	replaceAll: "replaceWith"
+    appendTo: "append",
+    prependTo: "prepend",
+    insertBefore: "before",
+    insertAfter: "after",
+    replaceAll: "replaceWith"
 }, function( name, original ) {
-	jQuery.fn[ name ] = function( selector ) {
-		var elems,
-			ret = [],
-			insert = jQuery( selector ),
-			last = insert.length - 1,
-			i = 0;
+    jQuery.fn[ name ] = function( selector ) {
+        var elems,
+            ret = [],
+            insert = jQuery( selector ),
+            last = insert.length - 1,
+            i = 0;
 
-		for ( ; i <= last; i++ ) {
-			elems = i === last ? this : this.clone( true );
-			jQuery( insert[ i ] )[ original ]( elems );
+        for ( ; i <= last; i++ ) {
+            elems = i === last ? this : this.clone( true );
+            jQuery( insert[ i ] )[ original ]( elems );
 
-			// Support: QtWebKit
-			// .get() because core_push.apply(_, arraylike) throws
-			core_push.apply( ret, elems.get() );
-		}
+            // Support: QtWebKit
+            // .get() because core_push.apply(_, arraylike) throws
+            core_push.apply( ret, elems.get() );
+        }
 
-		return this.pushStack( ret );
-	};
+        return this.pushStack( ret );
+    };
 });
 
 jQuery.extend({
-	clone: function( elem, dataAndEvents, deepDataAndEvents ) {
-		var i, l, srcElements, destElements,
-			clone = elem.cloneNode( true ),
-			inPage = jQuery.contains( elem.ownerDocument, elem );
+    clone: function( elem, dataAndEvents, deepDataAndEvents ) {
+        var i, l, srcElements, destElements,
+            clone = elem.cloneNode( true ),
+            inPage = jQuery.contains( elem.ownerDocument, elem );
 
-		// Support: IE >= 9
-		// Fix Cloning issues
-		if ( !jQuery.support.noCloneChecked && ( elem.nodeType === 1 || elem.nodeType === 11 ) && !jQuery.isXMLDoc( elem ) ) {
+        // Support: IE >= 9
+        // Fix Cloning issues
+        if ( !jQuery.support.noCloneChecked && ( elem.nodeType === 1 || elem.nodeType === 11 ) && !jQuery.isXMLDoc( elem ) ) {
 
-			// We eschew Sizzle here for performance reasons: http://jsperf.com/getall-vs-sizzle/2
-			destElements = getAll( clone );
-			srcElements = getAll( elem );
+            // We eschew Sizzle here for performance reasons: http://jsperf.com/getall-vs-sizzle/2
+            destElements = getAll( clone );
+            srcElements = getAll( elem );
 
-			for ( i = 0, l = srcElements.length; i < l; i++ ) {
-				fixInput( srcElements[ i ], destElements[ i ] );
-			}
-		}
+            for ( i = 0, l = srcElements.length; i < l; i++ ) {
+                fixInput( srcElements[ i ], destElements[ i ] );
+            }
+        }
 
-		// Copy the events from the original to the clone
-		if ( dataAndEvents ) {
-			if ( deepDataAndEvents ) {
-				srcElements = srcElements || getAll( elem );
-				destElements = destElements || getAll( clone );
+        // Copy the events from the original to the clone
+        if ( dataAndEvents ) {
+            if ( deepDataAndEvents ) {
+                srcElements = srcElements || getAll( elem );
+                destElements = destElements || getAll( clone );
 
-				for ( i = 0, l = srcElements.length; i < l; i++ ) {
-					cloneCopyEvent( srcElements[ i ], destElements[ i ] );
-				}
-			} else {
-				cloneCopyEvent( elem, clone );
-			}
-		}
+                for ( i = 0, l = srcElements.length; i < l; i++ ) {
+                    cloneCopyEvent( srcElements[ i ], destElements[ i ] );
+                }
+            } else {
+                cloneCopyEvent( elem, clone );
+            }
+        }
 
-		// Preserve script evaluation history
-		destElements = getAll( clone, "script" );
-		if ( destElements.length > 0 ) {
-			setGlobalEval( destElements, !inPage && getAll( elem, "script" ) );
-		}
+        // Preserve script evaluation history
+        destElements = getAll( clone, "script" );
+        if ( destElements.length > 0 ) {
+            setGlobalEval( destElements, !inPage && getAll( elem, "script" ) );
+        }
 
-		// Return the cloned set
-		return clone;
-	},
+        // Return the cloned set
+        return clone;
+    },
 
-	buildFragment: function( elems, context, scripts, selection ) {
-		var elem, tmp, tag, wrap, contains, j,
-			i = 0,
-			l = elems.length,
-			fragment = context.createDocumentFragment(),
-			nodes = [];
+    buildFragment: function( elems, context, scripts, selection ) {
+        var elem, tmp, tag, wrap, contains, j,
+            i = 0,
+            l = elems.length,
+            fragment = context.createDocumentFragment(),
+            nodes = [];
 
-		for ( ; i < l; i++ ) {
-			elem = elems[ i ];
+        for ( ; i < l; i++ ) {
+            elem = elems[ i ];
 
-			if ( elem || elem === 0 ) {
+            if ( elem || elem === 0 ) {
 
-				// Add nodes directly
-				if ( jQuery.type( elem ) === "object" ) {
-					// Support: QtWebKit
-					// jQuery.merge because core_push.apply(_, arraylike) throws
-					jQuery.merge( nodes, elem.nodeType ? [ elem ] : elem );
+                // Add nodes directly
+                if ( jQuery.type( elem ) === "object" ) {
+                    // Support: QtWebKit
+                    // jQuery.merge because core_push.apply(_, arraylike) throws
+                    jQuery.merge( nodes, elem.nodeType ? [ elem ] : elem );
 
-				// Convert non-html into a text node
-				} else if ( !rhtml.test( elem ) ) {
-					nodes.push( context.createTextNode( elem ) );
+                // Convert non-html into a text node
+                } else if ( !rhtml.test( elem ) ) {
+                    nodes.push( context.createTextNode( elem ) );
 
-				// Convert html into DOM nodes
-				} else {
-					tmp = tmp || fragment.appendChild( context.createElement("div") );
+                // Convert html into DOM nodes
+                } else {
+                    tmp = tmp || fragment.appendChild( context.createElement("div") );
 
-					// Deserialize a standard representation
-					tag = ( rtagName.exec( elem ) || ["", ""] )[ 1 ].toLowerCase();
-					wrap = wrapMap[ tag ] || wrapMap._default;
-					tmp.innerHTML = wrap[ 1 ] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[ 2 ];
+                    // Deserialize a standard representation
+                    tag = ( rtagName.exec( elem ) || ["", ""] )[ 1 ].toLowerCase();
+                    wrap = wrapMap[ tag ] || wrapMap._default;
+                    tmp.innerHTML = wrap[ 1 ] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[ 2 ];
 
-					// Descend through wrappers to the right content
-					j = wrap[ 0 ];
-					while ( j-- ) {
-						tmp = tmp.firstChild;
-					}
+                    // Descend through wrappers to the right content
+                    j = wrap[ 0 ];
+                    while ( j-- ) {
+                        tmp = tmp.firstChild;
+                    }
 
-					// Support: QtWebKit
-					// jQuery.merge because core_push.apply(_, arraylike) throws
-					jQuery.merge( nodes, tmp.childNodes );
+                    // Support: QtWebKit
+                    // jQuery.merge because core_push.apply(_, arraylike) throws
+                    jQuery.merge( nodes, tmp.childNodes );
 
-					// Remember the top-level container
-					tmp = fragment.firstChild;
+                    // Remember the top-level container
+                    tmp = fragment.firstChild;
 
-					// Fixes #12346
-					// Support: Webkit, IE
-					tmp.textContent = "";
-				}
-			}
-		}
+                    // Fixes #12346
+                    // Support: Webkit, IE
+                    tmp.textContent = "";
+                }
+            }
+        }
 
-		// Remove wrapper from fragment
-		fragment.textContent = "";
+        // Remove wrapper from fragment
+        fragment.textContent = "";
 
-		i = 0;
-		while ( (elem = nodes[ i++ ]) ) {
+        i = 0;
+        while ( (elem = nodes[ i++ ]) ) {
 
-			// #4087 - If origin and destination elements are the same, and this is
-			// that element, do not do anything
-			if ( selection && jQuery.inArray( elem, selection ) !== -1 ) {
-				continue;
-			}
+            // #4087 - If origin and destination elements are the same, and this is
+            // that element, do not do anything
+            if ( selection && jQuery.inArray( elem, selection ) !== -1 ) {
+                continue;
+            }
 
-			contains = jQuery.contains( elem.ownerDocument, elem );
+            contains = jQuery.contains( elem.ownerDocument, elem );
 
-			// Append to fragment
-			tmp = getAll( fragment.appendChild( elem ), "script" );
+            // Append to fragment
+            tmp = getAll( fragment.appendChild( elem ), "script" );
 
-			// Preserve script evaluation history
-			if ( contains ) {
-				setGlobalEval( tmp );
-			}
+            // Preserve script evaluation history
+            if ( contains ) {
+                setGlobalEval( tmp );
+            }
 
-			// Capture executables
-			if ( scripts ) {
-				j = 0;
-				while ( (elem = tmp[ j++ ]) ) {
-					if ( rscriptType.test( elem.type || "" ) ) {
-						scripts.push( elem );
-					}
-				}
-			}
-		}
+            // Capture executables
+            if ( scripts ) {
+                j = 0;
+                while ( (elem = tmp[ j++ ]) ) {
+                    if ( rscriptType.test( elem.type || "" ) ) {
+                        scripts.push( elem );
+                    }
+                }
+            }
+        }
 
-		return fragment;
-	},
+        return fragment;
+    },
 
-	cleanData: function( elems ) {
-		var data, elem, events, type, key, j,
-			special = jQuery.event.special,
-			i = 0;
+    cleanData: function( elems ) {
+        var data, elem, events, type, key, j,
+            special = jQuery.event.special,
+            i = 0;
 
-		for ( ; (elem = elems[ i ]) !== undefined; i++ ) {
-			if ( Data.accepts( elem ) ) {
-				key = elem[ data_priv.expando ];
+        for ( ; (elem = elems[ i ]) !== undefined; i++ ) {
+            if ( Data.accepts( elem ) ) {
+                key = elem[ data_priv.expando ];
 
-				if ( key && (data = data_priv.cache[ key ]) ) {
-					events = Object.keys( data.events || {} );
-					if ( events.length ) {
-						for ( j = 0; (type = events[j]) !== undefined; j++ ) {
-							if ( special[ type ] ) {
-								jQuery.event.remove( elem, type );
+                if ( key && (data = data_priv.cache[ key ]) ) {
+                    events = Object.keys( data.events || {} );
+                    if ( events.length ) {
+                        for ( j = 0; (type = events[j]) !== undefined; j++ ) {
+                            if ( special[ type ] ) {
+                                jQuery.event.remove( elem, type );
 
-							// This is a shortcut to avoid jQuery.event.remove's overhead
-							} else {
-								jQuery.removeEvent( elem, type, data.handle );
-							}
-						}
-					}
-					if ( data_priv.cache[ key ] ) {
-						// Discard any remaining `private` data
-						delete data_priv.cache[ key ];
-					}
-				}
-			}
-			// Discard any remaining `user` data
-			delete data_user.cache[ elem[ data_user.expando ] ];
-		}
-	},
+                            // This is a shortcut to avoid jQuery.event.remove's overhead
+                            } else {
+                                jQuery.removeEvent( elem, type, data.handle );
+                            }
+                        }
+                    }
+                    if ( data_priv.cache[ key ] ) {
+                        // Discard any remaining `private` data
+                        delete data_priv.cache[ key ];
+                    }
+                }
+            }
+            // Discard any remaining `user` data
+            delete data_user.cache[ elem[ data_user.expando ] ];
+        }
+    },
 
-	_evalUrl: function( url ) {
-		return jQuery.ajax({
-			url: url,
-			type: "GET",
-			dataType: "script",
-			async: false,
-			global: false,
-			"throws": true
-		});
-	}
+    _evalUrl: function( url ) {
+        return jQuery.ajax({
+            url: url,
+            type: "GET",
+            dataType: "script",
+            async: false,
+            global: false,
+            "throws": true
+        });
+    }
 });
 
 // Support: 1.x compatibility
 // Manipulating tables requires a tbody
 function manipulationTarget( elem, content ) {
-	return jQuery.nodeName( elem, "table" ) &&
-		jQuery.nodeName( content.nodeType === 1 ? content : content.firstChild, "tr" ) ?
+    return jQuery.nodeName( elem, "table" ) &&
+        jQuery.nodeName( content.nodeType === 1 ? content : content.firstChild, "tr" ) ?
 
-		elem.getElementsByTagName("tbody")[0] ||
-			elem.appendChild( elem.ownerDocument.createElement("tbody") ) :
-		elem;
+        elem.getElementsByTagName("tbody")[0] ||
+            elem.appendChild( elem.ownerDocument.createElement("tbody") ) :
+        elem;
 }
 
 // Replace/restore the type attribute of script elements for safe DOM manipulation
 function disableScript( elem ) {
-	elem.type = (elem.getAttribute("type") !== null) + "/" + elem.type;
-	return elem;
+    elem.type = (elem.getAttribute("type") !== null) + "/" + elem.type;
+    return elem;
 }
 function restoreScript( elem ) {
-	var match = rscriptTypeMasked.exec( elem.type );
+    var match = rscriptTypeMasked.exec( elem.type );
 
-	if ( match ) {
-		elem.type = match[ 1 ];
-	} else {
-		elem.removeAttribute("type");
-	}
+    if ( match ) {
+        elem.type = match[ 1 ];
+    } else {
+        elem.removeAttribute("type");
+    }
 
-	return elem;
+    return elem;
 }
 
 // Mark scripts as having already been evaluated
 function setGlobalEval( elems, refElements ) {
-	var l = elems.length,
-		i = 0;
+    var l = elems.length,
+        i = 0;
 
-	for ( ; i < l; i++ ) {
-		data_priv.set(
-			elems[ i ], "globalEval", !refElements || data_priv.get( refElements[ i ], "globalEval" )
-		);
-	}
+    for ( ; i < l; i++ ) {
+        data_priv.set(
+            elems[ i ], "globalEval", !refElements || data_priv.get( refElements[ i ], "globalEval" )
+        );
+    }
 }
 
 function cloneCopyEvent( src, dest ) {
-	var i, l, type, pdataOld, pdataCur, udataOld, udataCur, events;
+    var i, l, type, pdataOld, pdataCur, udataOld, udataCur, events;
 
-	if ( dest.nodeType !== 1 ) {
-		return;
-	}
+    if ( dest.nodeType !== 1 ) {
+        return;
+    }
 
-	// 1. Copy private data: events, handlers, etc.
-	if ( data_priv.hasData( src ) ) {
-		pdataOld = data_priv.access( src );
-		pdataCur = data_priv.set( dest, pdataOld );
-		events = pdataOld.events;
+    // 1. Copy private data: events, handlers, etc.
+    if ( data_priv.hasData( src ) ) {
+        pdataOld = data_priv.access( src );
+        pdataCur = data_priv.set( dest, pdataOld );
+        events = pdataOld.events;
 
-		if ( events ) {
-			delete pdataCur.handle;
-			pdataCur.events = {};
+        if ( events ) {
+            delete pdataCur.handle;
+            pdataCur.events = {};
 
-			for ( type in events ) {
-				for ( i = 0, l = events[ type ].length; i < l; i++ ) {
-					jQuery.event.add( dest, type, events[ type ][ i ] );
-				}
-			}
-		}
-	}
+            for ( type in events ) {
+                for ( i = 0, l = events[ type ].length; i < l; i++ ) {
+                    jQuery.event.add( dest, type, events[ type ][ i ] );
+                }
+            }
+        }
+    }
 
-	// 2. Copy user data
-	if ( data_user.hasData( src ) ) {
-		udataOld = data_user.access( src );
-		udataCur = jQuery.extend( {}, udataOld );
+    // 2. Copy user data
+    if ( data_user.hasData( src ) ) {
+        udataOld = data_user.access( src );
+        udataCur = jQuery.extend( {}, udataOld );
 
-		data_user.set( dest, udataCur );
-	}
+        data_user.set( dest, udataCur );
+    }
 }
 
 
 function getAll( context, tag ) {
-	var ret = context.getElementsByTagName ? context.getElementsByTagName( tag || "*" ) :
-			context.querySelectorAll ? context.querySelectorAll( tag || "*" ) :
-			[];
+    var ret = context.getElementsByTagName ? context.getElementsByTagName( tag || "*" ) :
+            context.querySelectorAll ? context.querySelectorAll( tag || "*" ) :
+            [];
 
-	return tag === undefined || tag && jQuery.nodeName( context, tag ) ?
-		jQuery.merge( [ context ], ret ) :
-		ret;
+    return tag === undefined || tag && jQuery.nodeName( context, tag ) ?
+        jQuery.merge( [ context ], ret ) :
+        ret;
 }
 
 // Support: IE >= 9
 function fixInput( src, dest ) {
-	var nodeName = dest.nodeName.toLowerCase();
+    var nodeName = dest.nodeName.toLowerCase();
 
-	// Fails to persist the checked state of a cloned checkbox or radio button.
-	if ( nodeName === "input" && manipulation_rcheckableType.test( src.type ) ) {
-		dest.checked = src.checked;
+    // Fails to persist the checked state of a cloned checkbox or radio button.
+    if ( nodeName === "input" && manipulation_rcheckableType.test( src.type ) ) {
+        dest.checked = src.checked;
 
-	// Fails to return the selected option to the default selected state when cloning options
-	} else if ( nodeName === "input" || nodeName === "textarea" ) {
-		dest.defaultValue = src.defaultValue;
-	}
+    // Fails to return the selected option to the default selected state when cloning options
+    } else if ( nodeName === "input" || nodeName === "textarea" ) {
+        dest.defaultValue = src.defaultValue;
+    }
 }
+jQuery.fn.extend({
+    wrapAll: function( html ) {
+        var wrap;
+
+        if ( jQuery.isFunction( html ) ) {
+            return this.each(function( i ) {
+                jQuery( this ).wrapAll( html.call(this, i) );
+            });
+        }
+
+        if ( this[ 0 ] ) {
+
+            // The elements to wrap the target around
+            wrap = jQuery( html, this[ 0 ].ownerDocument ).eq( 0 ).clone( true );
+
+            if ( this[ 0 ].parentNode ) {
+                wrap.insertBefore( this[ 0 ] );
+            }
+
+            wrap.map(function() {
+                var elem = this;
+
+                while ( elem.firstElementChild ) {
+                    elem = elem.firstElementChild;
+                }
+
+                return elem;
+            }).append( this );
+        }
+
+        return this;
+    },
+
+    wrapInner: function( html ) {
+        if ( jQuery.isFunction( html ) ) {
+            return this.each(function( i ) {
+                jQuery( this ).wrapInner( html.call(this, i) );
+            });
+        }
+
+        return this.each(function() {
+            var self = jQuery( this ),
+                contents = self.contents();
+
+            if ( contents.length ) {
+                contents.wrapAll( html );
+
+            } else {
+                self.append( html );
+            }
+        });
+    },
+
+    wrap: function( html ) {
+        var isFunction = jQuery.isFunction( html );
+
+        return this.each(function( i ) {
+            jQuery( this ).wrapAll( isFunction ? html.call(this, i) : html );
+        });
+    },
+
+    unwrap: function() {
+        return this.parent().each(function() {
+            if ( !jQuery.nodeName( this, "body" ) ) {
+                jQuery( this ).replaceWith( this.childNodes );
+            }
+        }).end();
+    }
+});
 var curCSS, iframe,
-	// swappable if display is none or starts with table except "table", "table-cell", or "table-caption"
-	// see here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
-	rdisplayswap = /^(none|table(?!-c[ea]).+)/,
-	rmargin = /^margin/,
-	rnumsplit = new RegExp( "^(" + core_pnum + ")(.*)$", "i" ),
-	rnumnonpx = new RegExp( "^(" + core_pnum + ")(?!px)[a-z%]+$", "i" ),
-	rrelNum = new RegExp( "^([+-])=(" + core_pnum + ")", "i" ),
-	elemdisplay = { BODY: "block" },
+    // swappable if display is none or starts with table except "table", "table-cell", or "table-caption"
+    // see here for display values: https://developer.mozilla.org/en-US/docs/CSS/display
+    rdisplayswap = /^(none|table(?!-c[ea]).+)/,
+    rmargin = /^margin/,
+    rnumsplit = new RegExp( "^(" + core_pnum + ")(.*)$", "i" ),
+    rnumnonpx = new RegExp( "^(" + core_pnum + ")(?!px)[a-z%]+$", "i" ),
+    rrelNum = new RegExp( "^([+-])=(" + core_pnum + ")", "i" ),
+    elemdisplay = { BODY: "block" },
 
-	cssShow = { position: "absolute", visibility: "hidden", display: "block" },
-	cssNormalTransform = {
-		letterSpacing: 0,
-		fontWeight: 400
-	},
+    cssShow = { position: "absolute", visibility: "hidden", display: "block" },
+    cssNormalTransform = {
+        letterSpacing: 0,
+        fontWeight: 400
+    },
 
-	cssExpand = [ "Top", "Right", "Bottom", "Left" ],
-	cssPrefixes = [ "Webkit", "O", "Moz", "ms" ];
+    cssExpand = [ "Top", "Right", "Bottom", "Left" ],
+    cssPrefixes = [ "Webkit", "O", "Moz", "ms" ];
 
 // return a css property mapped to a potentially vendor prefixed property
 function vendorPropName( style, name ) {
 
-	// shortcut for names that are not vendor prefixed
-	if ( name in style ) {
-		return name;
-	}
+    // shortcut for names that are not vendor prefixed
+    if ( name in style ) {
+        return name;
+    }
 
-	// check for vendor prefixed names
-	var capName = name.charAt(0).toUpperCase() + name.slice(1),
-		origName = name,
-		i = cssPrefixes.length;
+    // check for vendor prefixed names
+    var capName = name.charAt(0).toUpperCase() + name.slice(1),
+        origName = name,
+        i = cssPrefixes.length;
 
-	while ( i-- ) {
-		name = cssPrefixes[ i ] + capName;
-		if ( name in style ) {
-			return name;
-		}
-	}
+    while ( i-- ) {
+        name = cssPrefixes[ i ] + capName;
+        if ( name in style ) {
+            return name;
+        }
+    }
 
-	return origName;
+    return origName;
 }
 
 function isHidden( elem, el ) {
-	// isHidden might be called from jQuery#filter function;
-	// in that case, element will be second argument
-	elem = el || elem;
-	return jQuery.css( elem, "display" ) === "none" || !jQuery.contains( elem.ownerDocument, elem );
+    // isHidden might be called from jQuery#filter function;
+    // in that case, element will be second argument
+    elem = el || elem;
+    return jQuery.css( elem, "display" ) === "none" || !jQuery.contains( elem.ownerDocument, elem );
 }
 
 // NOTE: we've included the "window" in window.getComputedStyle
 // because jsdom on node.js will break without it.
 function getStyles( elem ) {
-	return window.getComputedStyle( elem, null );
+    return window.getComputedStyle( elem, null );
 }
 
 function showHide( elements, show ) {
-	var display, elem, hidden,
-		values = [],
-		index = 0,
-		length = elements.length;
+    var display, elem, hidden,
+        values = [],
+        index = 0,
+        length = elements.length;
 
-	for ( ; index < length; index++ ) {
-		elem = elements[ index ];
-		if ( !elem.style ) {
-			continue;
-		}
+    for ( ; index < length; index++ ) {
+        elem = elements[ index ];
+        if ( !elem.style ) {
+            continue;
+        }
 
-		values[ index ] = data_priv.get( elem, "olddisplay" );
-		display = elem.style.display;
-		if ( show ) {
-			// Reset the inline display of this element to learn if it is
-			// being hidden by cascaded rules or not
-			if ( !values[ index ] && display === "none" ) {
-				elem.style.display = "";
-			}
+        values[ index ] = data_priv.get( elem, "olddisplay" );
+        display = elem.style.display;
+        if ( show ) {
+            // Reset the inline display of this element to learn if it is
+            // being hidden by cascaded rules or not
+            if ( !values[ index ] && display === "none" ) {
+                elem.style.display = "";
+            }
 
-			// Set elements which have been overridden with display: none
-			// in a stylesheet to whatever the default browser style is
-			// for such an element
-			if ( elem.style.display === "" && isHidden( elem ) ) {
-				values[ index ] = data_priv.access( elem, "olddisplay", css_defaultDisplay(elem.nodeName) );
-			}
-		} else {
+            // Set elements which have been overridden with display: none
+            // in a stylesheet to whatever the default browser style is
+            // for such an element
+            if ( elem.style.display === "" && isHidden( elem ) ) {
+                values[ index ] = data_priv.access( elem, "olddisplay", css_defaultDisplay(elem.nodeName) );
+            }
+        } else {
 
-			if ( !values[ index ] ) {
-				hidden = isHidden( elem );
+            if ( !values[ index ] ) {
+                hidden = isHidden( elem );
 
-				if ( display && display !== "none" || !hidden ) {
-					data_priv.set( elem, "olddisplay", hidden ? display : jQuery.css(elem, "display") );
-				}
-			}
-		}
-	}
+                if ( display && display !== "none" || !hidden ) {
+                    data_priv.set( elem, "olddisplay", hidden ? display : jQuery.css(elem, "display") );
+                }
+            }
+        }
+    }
 
-	// Set the display of most of the elements in a second loop
-	// to avoid the constant reflow
-	for ( index = 0; index < length; index++ ) {
-		elem = elements[ index ];
-		if ( !elem.style ) {
-			continue;
-		}
-		if ( !show || elem.style.display === "none" || elem.style.display === "" ) {
-			elem.style.display = show ? values[ index ] || "" : "none";
-		}
-	}
+    // Set the display of most of the elements in a second loop
+    // to avoid the constant reflow
+    for ( index = 0; index < length; index++ ) {
+        elem = elements[ index ];
+        if ( !elem.style ) {
+            continue;
+        }
+        if ( !show || elem.style.display === "none" || elem.style.display === "" ) {
+            elem.style.display = show ? values[ index ] || "" : "none";
+        }
+    }
 
-	return elements;
+    return elements;
 }
 
 jQuery.fn.extend({
-	css: function( name, value ) {
-		return jQuery.access( this, function( elem, name, value ) {
-			var styles, len,
-				map = {},
-				i = 0;
+    css: function( name, value ) {
+        return jQuery.access( this, function( elem, name, value ) {
+            var styles, len,
+                map = {},
+                i = 0;
 
-			if ( jQuery.isArray( name ) ) {
-				styles = getStyles( elem );
-				len = name.length;
+            if ( jQuery.isArray( name ) ) {
+                styles = getStyles( elem );
+                len = name.length;
 
-				for ( ; i < len; i++ ) {
-					map[ name[ i ] ] = jQuery.css( elem, name[ i ], false, styles );
-				}
+                for ( ; i < len; i++ ) {
+                    map[ name[ i ] ] = jQuery.css( elem, name[ i ], false, styles );
+                }
 
-				return map;
-			}
+                return map;
+            }
 
-			return value !== undefined ?
-				jQuery.style( elem, name, value ) :
-				jQuery.css( elem, name );
-		}, name, value, arguments.length > 1 );
-	},
-	show: function() {
-		return showHide( this, true );
-	},
-	hide: function() {
-		return showHide( this );
-	},
-	toggle: function( state ) {
-		var bool = typeof state === "boolean";
+            return value !== undefined ?
+                jQuery.style( elem, name, value ) :
+                jQuery.css( elem, name );
+        }, name, value, arguments.length > 1 );
+    },
+    show: function() {
+        return showHide( this, true );
+    },
+    hide: function() {
+        return showHide( this );
+    },
+    toggle: function( state ) {
+        var bool = typeof state === "boolean";
 
-		return this.each(function() {
-			if ( bool ? state : isHidden( this ) ) {
-				jQuery( this ).show();
-			} else {
-				jQuery( this ).hide();
-			}
-		});
-	}
+        return this.each(function() {
+            if ( bool ? state : isHidden( this ) ) {
+                jQuery( this ).show();
+            } else {
+                jQuery( this ).hide();
+            }
+        });
+    }
 });
 
 jQuery.extend({
-	// Add in style property hooks for overriding the default
-	// behavior of getting and setting a style property
-	cssHooks: {
-		opacity: {
-			get: function( elem, computed ) {
-				if ( computed ) {
-					// We should always get a number back from opacity
-					var ret = curCSS( elem, "opacity" );
-					return ret === "" ? "1" : ret;
-				}
-			}
-		}
-	},
+    // Add in style property hooks for overriding the default
+    // behavior of getting and setting a style property
+    cssHooks: {
+        opacity: {
+            get: function( elem, computed ) {
+                if ( computed ) {
+                    // We should always get a number back from opacity
+                    var ret = curCSS( elem, "opacity" );
+                    return ret === "" ? "1" : ret;
+                }
+            }
+        }
+    },
 
-	// Don't automatically add "px" to these possibly-unitless properties
-	cssNumber: {
-		"columnCount": true,
-		"fillOpacity": true,
-		"fontWeight": true,
-		"lineHeight": true,
-		"opacity": true,
-		"orphans": true,
-		"widows": true,
-		"zIndex": true,
-		"zoom": true
-	},
+    // Don't automatically add "px" to these possibly-unitless properties
+    cssNumber: {
+        "columnCount": true,
+        "fillOpacity": true,
+        "fontWeight": true,
+        "lineHeight": true,
+        "opacity": true,
+        "orphans": true,
+        "widows": true,
+        "zIndex": true,
+        "zoom": true
+    },
 
-	// Add in properties whose names you wish to fix before
-	// setting or getting the value
-	cssProps: {
-		// normalize float css property
-		"float": "cssFloat"
-	},
+    // Add in properties whose names you wish to fix before
+    // setting or getting the value
+    cssProps: {
+        // normalize float css property
+        "float": "cssFloat"
+    },
 
-	// Get and set the style property on a DOM Node
-	style: function( elem, name, value, extra ) {
-		// Don't set styles on text and comment nodes
-		if ( !elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style ) {
-			return;
-		}
+    // Get and set the style property on a DOM Node
+    style: function( elem, name, value, extra ) {
+        // Don't set styles on text and comment nodes
+        if ( !elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style ) {
+            return;
+        }
 
-		// Make sure that we're working with the right name
-		var ret, type, hooks,
-			origName = jQuery.camelCase( name ),
-			style = elem.style;
+        // Make sure that we're working with the right name
+        var ret, type, hooks,
+            origName = jQuery.camelCase( name ),
+            style = elem.style;
 
-		name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( style, origName ) );
+        name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( style, origName ) );
 
-		// gets hook for the prefixed version
-		// followed by the unprefixed version
-		hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
+        // gets hook for the prefixed version
+        // followed by the unprefixed version
+        hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
 
-		// Check if we're setting a value
-		if ( value !== undefined ) {
-			type = typeof value;
+        // Check if we're setting a value
+        if ( value !== undefined ) {
+            type = typeof value;
 
-			// convert relative number strings (+= or -=) to relative numbers. #7345
-			if ( type === "string" && (ret = rrelNum.exec( value )) ) {
-				value = ( ret[1] + 1 ) * ret[2] + parseFloat( jQuery.css( elem, name ) );
-				// Fixes bug #9237
-				type = "number";
-			}
+            // convert relative number strings (+= or -=) to relative numbers. #7345
+            if ( type === "string" && (ret = rrelNum.exec( value )) ) {
+                value = ( ret[1] + 1 ) * ret[2] + parseFloat( jQuery.css( elem, name ) );
+                // Fixes bug #9237
+                type = "number";
+            }
 
-			// Make sure that NaN and null values aren't set. See: #7116
-			if ( value == null || type === "number" && isNaN( value ) ) {
-				return;
-			}
+            // Make sure that NaN and null values aren't set. See: #7116
+            if ( value == null || type === "number" && isNaN( value ) ) {
+                return;
+            }
 
-			// If a number was passed in, add 'px' to the (except for certain CSS properties)
-			if ( type === "number" && !jQuery.cssNumber[ origName ] ) {
-				value += "px";
-			}
+            // If a number was passed in, add 'px' to the (except for certain CSS properties)
+            if ( type === "number" && !jQuery.cssNumber[ origName ] ) {
+                value += "px";
+            }
 
-			// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
-			// but it would mean to define eight (for every problematic property) identical functions
-			if ( !jQuery.support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
-				style[ name ] = "inherit";
-			}
+            // Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
+            // but it would mean to define eight (for every problematic property) identical functions
+            if ( !jQuery.support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
+                style[ name ] = "inherit";
+            }
 
-			// If a hook was provided, use that value, otherwise just set the specified value
-			if ( !hooks || !("set" in hooks) || (value = hooks.set( elem, value, extra )) !== undefined ) {
-				style[ name ] = value;
-			}
+            // If a hook was provided, use that value, otherwise just set the specified value
+            if ( !hooks || !("set" in hooks) || (value = hooks.set( elem, value, extra )) !== undefined ) {
+                style[ name ] = value;
+            }
 
-		} else {
-			// If a hook was provided get the non-computed value from there
-			if ( hooks && "get" in hooks && (ret = hooks.get( elem, false, extra )) !== undefined ) {
-				return ret;
-			}
+        } else {
+            // If a hook was provided get the non-computed value from there
+            if ( hooks && "get" in hooks && (ret = hooks.get( elem, false, extra )) !== undefined ) {
+                return ret;
+            }
 
-			// Otherwise just get the value from the style object
-			return style[ name ];
-		}
-	},
+            // Otherwise just get the value from the style object
+            return style[ name ];
+        }
+    },
 
-	css: function( elem, name, extra, styles ) {
-		var val, num, hooks,
-			origName = jQuery.camelCase( name );
+    css: function( elem, name, extra, styles ) {
+        var val, num, hooks,
+            origName = jQuery.camelCase( name );
 
-		// Make sure that we're working with the right name
-		name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( elem.style, origName ) );
+        // Make sure that we're working with the right name
+        name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( elem.style, origName ) );
 
-		// gets hook for the prefixed version
-		// followed by the unprefixed version
-		hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
+        // gets hook for the prefixed version
+        // followed by the unprefixed version
+        hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
 
-		// If a hook was provided get the computed value from there
-		if ( hooks && "get" in hooks ) {
-			val = hooks.get( elem, true, extra );
-		}
+        // If a hook was provided get the computed value from there
+        if ( hooks && "get" in hooks ) {
+            val = hooks.get( elem, true, extra );
+        }
 
-		// Otherwise, if a way to get the computed value exists, use that
-		if ( val === undefined ) {
-			val = curCSS( elem, name, styles );
-		}
+        // Otherwise, if a way to get the computed value exists, use that
+        if ( val === undefined ) {
+            val = curCSS( elem, name, styles );
+        }
 
-		//convert "normal" to computed value
-		if ( val === "normal" && name in cssNormalTransform ) {
-			val = cssNormalTransform[ name ];
-		}
+        //convert "normal" to computed value
+        if ( val === "normal" && name in cssNormalTransform ) {
+            val = cssNormalTransform[ name ];
+        }
 
-		// Return, converting to number if forced or a qualifier was provided and val looks numeric
-		if ( extra === "" || extra ) {
-			num = parseFloat( val );
-			return extra === true || jQuery.isNumeric( num ) ? num || 0 : val;
-		}
-		return val;
-	}
+        // Return, converting to number if forced or a qualifier was provided and val looks numeric
+        if ( extra === "" || extra ) {
+            num = parseFloat( val );
+            return extra === true || jQuery.isNumeric( num ) ? num || 0 : val;
+        }
+        return val;
+    }
 });
 
 curCSS = function( elem, name, _computed ) {
-	var width, minWidth, maxWidth,
-		computed = _computed || getStyles( elem ),
+    var width, minWidth, maxWidth,
+        computed = _computed || getStyles( elem ),
 
-		// Support: IE9
-		// getPropertyValue is only needed for .css('filter') in IE9, see #12537
-		ret = computed ? computed.getPropertyValue( name ) || computed[ name ] : undefined,
-		style = elem.style;
+        // Support: IE9
+        // getPropertyValue is only needed for .css('filter') in IE9, see #12537
+        ret = computed ? computed.getPropertyValue( name ) || computed[ name ] : undefined,
+        style = elem.style;
 
-	if ( computed ) {
+    if ( computed ) {
 
-		if ( ret === "" && !jQuery.contains( elem.ownerDocument, elem ) ) {
-			ret = jQuery.style( elem, name );
-		}
+        if ( ret === "" && !jQuery.contains( elem.ownerDocument, elem ) ) {
+            ret = jQuery.style( elem, name );
+        }
 
-		// Support: Safari 5.1
-		// A tribute to the "awesome hack by Dean Edwards"
-		// Safari 5.1.7 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
-		// this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
-		if ( rnumnonpx.test( ret ) && rmargin.test( name ) ) {
+        // Support: Safari 5.1
+        // A tribute to the "awesome hack by Dean Edwards"
+        // Safari 5.1.7 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
+        // this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
+        if ( rnumnonpx.test( ret ) && rmargin.test( name ) ) {
 
-			// Remember the original values
-			width = style.width;
-			minWidth = style.minWidth;
-			maxWidth = style.maxWidth;
+            // Remember the original values
+            width = style.width;
+            minWidth = style.minWidth;
+            maxWidth = style.maxWidth;
 
-			// Put in the new values to get a computed value out
-			style.minWidth = style.maxWidth = style.width = ret;
-			ret = computed.width;
+            // Put in the new values to get a computed value out
+            style.minWidth = style.maxWidth = style.width = ret;
+            ret = computed.width;
 
-			// Revert the changed values
-			style.width = width;
-			style.minWidth = minWidth;
-			style.maxWidth = maxWidth;
-		}
-	}
+            // Revert the changed values
+            style.width = width;
+            style.minWidth = minWidth;
+            style.maxWidth = maxWidth;
+        }
+    }
 
-	return ret;
+    return ret;
 };
 
 
 function setPositiveNumber( elem, value, subtract ) {
-	var matches = rnumsplit.exec( value );
-	return matches ?
-		// Guard against undefined "subtract", e.g., when used as in cssHooks
-		Math.max( 0, matches[ 1 ] - ( subtract || 0 ) ) + ( matches[ 2 ] || "px" ) :
-		value;
+    var matches = rnumsplit.exec( value );
+    return matches ?
+        // Guard against undefined "subtract", e.g., when used as in cssHooks
+        Math.max( 0, matches[ 1 ] - ( subtract || 0 ) ) + ( matches[ 2 ] || "px" ) :
+        value;
 }
 
 function augmentWidthOrHeight( elem, name, extra, isBorderBox, styles ) {
-	var i = extra === ( isBorderBox ? "border" : "content" ) ?
-		// If we already have the right measurement, avoid augmentation
-		4 :
-		// Otherwise initialize for horizontal or vertical properties
-		name === "width" ? 1 : 0,
+    var i = extra === ( isBorderBox ? "border" : "content" ) ?
+        // If we already have the right measurement, avoid augmentation
+        4 :
+        // Otherwise initialize for horizontal or vertical properties
+        name === "width" ? 1 : 0,
 
-		val = 0;
+        val = 0;
 
-	for ( ; i < 4; i += 2 ) {
-		// both box models exclude margin, so add it if we want it
-		if ( extra === "margin" ) {
-			val += jQuery.css( elem, extra + cssExpand[ i ], true, styles );
-		}
+    for ( ; i < 4; i += 2 ) {
+        // both box models exclude margin, so add it if we want it
+        if ( extra === "margin" ) {
+            val += jQuery.css( elem, extra + cssExpand[ i ], true, styles );
+        }
 
-		if ( isBorderBox ) {
-			// border-box includes padding, so remove it if we want content
-			if ( extra === "content" ) {
-				val -= jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
-			}
+        if ( isBorderBox ) {
+            // border-box includes padding, so remove it if we want content
+            if ( extra === "content" ) {
+                val -= jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
+            }
 
-			// at this point, extra isn't border nor margin, so remove border
-			if ( extra !== "margin" ) {
-				val -= jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
-			}
-		} else {
-			// at this point, extra isn't content, so add padding
-			val += jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
+            // at this point, extra isn't border nor margin, so remove border
+            if ( extra !== "margin" ) {
+                val -= jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+            }
+        } else {
+            // at this point, extra isn't content, so add padding
+            val += jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
 
-			// at this point, extra isn't content nor padding, so add border
-			if ( extra !== "padding" ) {
-				val += jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
-			}
-		}
-	}
+            // at this point, extra isn't content nor padding, so add border
+            if ( extra !== "padding" ) {
+                val += jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
+            }
+        }
+    }
 
-	return val;
+    return val;
 }
 
 function getWidthOrHeight( elem, name, extra ) {
 
-	// Start with offset property, which is equivalent to the border-box value
-	var valueIsBorderBox = true,
-		val = name === "width" ? elem.offsetWidth : elem.offsetHeight,
-		styles = getStyles( elem ),
-		isBorderBox = jQuery.support.boxSizing && jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
+    // Start with offset property, which is equivalent to the border-box value
+    var valueIsBorderBox = true,
+        val = name === "width" ? elem.offsetWidth : elem.offsetHeight,
+        styles = getStyles( elem ),
+        isBorderBox = jQuery.support.boxSizing && jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
 
-	// some non-html elements return undefined for offsetWidth, so check for null/undefined
-	// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
-	// MathML - https://bugzilla.mozilla.org/show_bug.cgi?id=491668
-	if ( val <= 0 || val == null ) {
-		// Fall back to computed then uncomputed css if necessary
-		val = curCSS( elem, name, styles );
-		if ( val < 0 || val == null ) {
-			val = elem.style[ name ];
-		}
+    // some non-html elements return undefined for offsetWidth, so check for null/undefined
+    // svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
+    // MathML - https://bugzilla.mozilla.org/show_bug.cgi?id=491668
+    if ( val <= 0 || val == null ) {
+        // Fall back to computed then uncomputed css if necessary
+        val = curCSS( elem, name, styles );
+        if ( val < 0 || val == null ) {
+            val = elem.style[ name ];
+        }
 
-		// Computed unit is not pixels. Stop here and return.
-		if ( rnumnonpx.test(val) ) {
-			return val;
-		}
+        // Computed unit is not pixels. Stop here and return.
+        if ( rnumnonpx.test(val) ) {
+            return val;
+        }
 
-		// we need the check for style in case a browser which returns unreliable values
-		// for getComputedStyle silently falls back to the reliable elem.style
-		valueIsBorderBox = isBorderBox && ( jQuery.support.boxSizingReliable || val === elem.style[ name ] );
+        // we need the check for style in case a browser which returns unreliable values
+        // for getComputedStyle silently falls back to the reliable elem.style
+        valueIsBorderBox = isBorderBox && ( jQuery.support.boxSizingReliable || val === elem.style[ name ] );
 
-		// Normalize "", auto, and prepare for extra
-		val = parseFloat( val ) || 0;
-	}
+        // Normalize "", auto, and prepare for extra
+        val = parseFloat( val ) || 0;
+    }
 
-	// use the active box-sizing model to add/subtract irrelevant styles
-	return ( val +
-		augmentWidthOrHeight(
-			elem,
-			name,
-			extra || ( isBorderBox ? "border" : "content" ),
-			valueIsBorderBox,
-			styles
-		)
-	) + "px";
+    // use the active box-sizing model to add/subtract irrelevant styles
+    return ( val +
+        augmentWidthOrHeight(
+            elem,
+            name,
+            extra || ( isBorderBox ? "border" : "content" ),
+            valueIsBorderBox,
+            styles
+        )
+    ) + "px";
 }
 
 // Try to determine the default display value of an element
 function css_defaultDisplay( nodeName ) {
-	var doc = document,
-		display = elemdisplay[ nodeName ];
+    var doc = document,
+        display = elemdisplay[ nodeName ];
 
-	if ( !display ) {
-		display = actualDisplay( nodeName, doc );
+    if ( !display ) {
+        display = actualDisplay( nodeName, doc );
 
-		// If the simple way fails, read from inside an iframe
-		if ( display === "none" || !display ) {
-			// Use the already-created iframe if possible
-			iframe = ( iframe ||
-				jQuery("<iframe frameborder='0' width='0' height='0'/>")
-				.css( "cssText", "display:block !important" )
-			).appendTo( doc.documentElement );
+        // If the simple way fails, read from inside an iframe
+        if ( display === "none" || !display ) {
+            // Use the already-created iframe if possible
+            iframe = ( iframe ||
+                jQuery("<iframe frameborder='0' width='0' height='0'/>")
+                .css( "cssText", "display:block !important" )
+            ).appendTo( doc.documentElement );
 
-			// Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
-			doc = ( iframe[0].contentWindow || iframe[0].contentDocument ).document;
-			doc.write("<!doctype html><html><body>");
-			doc.close();
+            // Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
+            doc = ( iframe[0].contentWindow || iframe[0].contentDocument ).document;
+            doc.write("<!doctype html><html><body>");
+            doc.close();
 
-			display = actualDisplay( nodeName, doc );
-			iframe.detach();
-		}
+            display = actualDisplay( nodeName, doc );
+            iframe.detach();
+        }
 
-		// Store the correct default display
-		elemdisplay[ nodeName ] = display;
-	}
+        // Store the correct default display
+        elemdisplay[ nodeName ] = display;
+    }
 
-	return display;
+    return display;
 }
 
 // Called ONLY from within css_defaultDisplay
 function actualDisplay( name, doc ) {
-	var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
-		display = jQuery.css( elem[0], "display" );
-	elem.remove();
-	return display;
+    var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
+        display = jQuery.css( elem[0], "display" );
+    elem.remove();
+    return display;
 }
 
 jQuery.each([ "height", "width" ], function( i, name ) {
-	jQuery.cssHooks[ name ] = {
-		get: function( elem, computed, extra ) {
-			if ( computed ) {
-				// certain elements can have dimension info if we invisibly show them
-				// however, it must have a current display style that would benefit from this
-				return elem.offsetWidth === 0 && rdisplayswap.test( jQuery.css( elem, "display" ) ) ?
-					jQuery.swap( elem, cssShow, function() {
-						return getWidthOrHeight( elem, name, extra );
-					}) :
-					getWidthOrHeight( elem, name, extra );
-			}
-		},
+    jQuery.cssHooks[ name ] = {
+        get: function( elem, computed, extra ) {
+            if ( computed ) {
+                // certain elements can have dimension info if we invisibly show them
+                // however, it must have a current display style that would benefit from this
+                return elem.offsetWidth === 0 && rdisplayswap.test( jQuery.css( elem, "display" ) ) ?
+                    jQuery.swap( elem, cssShow, function() {
+                        return getWidthOrHeight( elem, name, extra );
+                    }) :
+                    getWidthOrHeight( elem, name, extra );
+            }
+        },
 
-		set: function( elem, value, extra ) {
-			var styles = extra && getStyles( elem );
-			return setPositiveNumber( elem, value, extra ?
-				augmentWidthOrHeight(
-					elem,
-					name,
-					extra,
-					jQuery.support.boxSizing && jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
-					styles
-				) : 0
-			);
-		}
-	};
+        set: function( elem, value, extra ) {
+            var styles = extra && getStyles( elem );
+            return setPositiveNumber( elem, value, extra ?
+                augmentWidthOrHeight(
+                    elem,
+                    name,
+                    extra,
+                    jQuery.support.boxSizing && jQuery.css( elem, "boxSizing", false, styles ) === "border-box",
+                    styles
+                ) : 0
+            );
+        }
+    };
 });
 
 // These hooks cannot be added until DOM ready because the support test
 // for it is not run until after DOM ready
 jQuery(function() {
-	// Support: Android 2.3
-	if ( !jQuery.support.reliableMarginRight ) {
-		jQuery.cssHooks.marginRight = {
-			get: function( elem, computed ) {
-				if ( computed ) {
-					// Support: Android 2.3
-					// WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
-					// Work around by temporarily setting element display to inline-block
-					return jQuery.swap( elem, { "display": "inline-block" },
-						curCSS, [ elem, "marginRight" ] );
-				}
-			}
-		};
-	}
+    // Support: Android 2.3
+    if ( !jQuery.support.reliableMarginRight ) {
+        jQuery.cssHooks.marginRight = {
+            get: function( elem, computed ) {
+                if ( computed ) {
+                    // Support: Android 2.3
+                    // WebKit Bug 13343 - getComputedStyle returns wrong value for margin-right
+                    // Work around by temporarily setting element display to inline-block
+                    return jQuery.swap( elem, { "display": "inline-block" },
+                        curCSS, [ elem, "marginRight" ] );
+                }
+            }
+        };
+    }
 
-	// Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
-	// getComputedStyle returns percent when specified for top/left/bottom/right
-	// rather than make the css module depend on the offset module, we just check for it here
-	if ( !jQuery.support.pixelPosition && jQuery.fn.position ) {
-		jQuery.each( [ "top", "left" ], function( i, prop ) {
-			jQuery.cssHooks[ prop ] = {
-				get: function( elem, computed ) {
-					if ( computed ) {
-						computed = curCSS( elem, prop );
-						// if curCSS returns percentage, fallback to offset
-						return rnumnonpx.test( computed ) ?
-							jQuery( elem ).position()[ prop ] + "px" :
-							computed;
-					}
-				}
-			};
-		});
-	}
+    // Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
+    // getComputedStyle returns percent when specified for top/left/bottom/right
+    // rather than make the css module depend on the offset module, we just check for it here
+    if ( !jQuery.support.pixelPosition && jQuery.fn.position ) {
+        jQuery.each( [ "top", "left" ], function( i, prop ) {
+            jQuery.cssHooks[ prop ] = {
+                get: function( elem, computed ) {
+                    if ( computed ) {
+                        computed = curCSS( elem, prop );
+                        // if curCSS returns percentage, fallback to offset
+                        return rnumnonpx.test( computed ) ?
+                            jQuery( elem ).position()[ prop ] + "px" :
+                            computed;
+                    }
+                }
+            };
+        });
+    }
 
 });
 
 if ( jQuery.expr && jQuery.expr.filters ) {
-	jQuery.expr.filters.hidden = function( elem ) {
-		// Support: Opera <= 12.12
-		// Opera reports offsetWidths and offsetHeights less than zero on some elements
-		return elem.offsetWidth <= 0 && elem.offsetHeight <= 0;
-	};
+    jQuery.expr.filters.hidden = function( elem ) {
+        // Support: Opera <= 12.12
+        // Opera reports offsetWidths and offsetHeights less than zero on some elements
+        return elem.offsetWidth <= 0 && elem.offsetHeight <= 0;
+    };
 
-	jQuery.expr.filters.visible = function( elem ) {
-		return !jQuery.expr.filters.hidden( elem );
-	};
+    jQuery.expr.filters.visible = function( elem ) {
+        return !jQuery.expr.filters.hidden( elem );
+    };
 }
 
 // These hooks are used by animate to expand properties
 jQuery.each({
-	margin: "",
-	padding: "",
-	border: "Width"
+    margin: "",
+    padding: "",
+    border: "Width"
 }, function( prefix, suffix ) {
-	jQuery.cssHooks[ prefix + suffix ] = {
-		expand: function( value ) {
-			var i = 0,
-				expanded = {},
+    jQuery.cssHooks[ prefix + suffix ] = {
+        expand: function( value ) {
+            var i = 0,
+                expanded = {},
 
-				// assumes a single number if not a string
-				parts = typeof value === "string" ? value.split(" ") : [ value ];
+                // assumes a single number if not a string
+                parts = typeof value === "string" ? value.split(" ") : [ value ];
 
-			for ( ; i < 4; i++ ) {
-				expanded[ prefix + cssExpand[ i ] + suffix ] =
-					parts[ i ] || parts[ i - 2 ] || parts[ 0 ];
-			}
+            for ( ; i < 4; i++ ) {
+                expanded[ prefix + cssExpand[ i ] + suffix ] =
+                    parts[ i ] || parts[ i - 2 ] || parts[ 0 ];
+            }
 
-			return expanded;
-		}
-	};
+            return expanded;
+        }
+    };
 
-	if ( !rmargin.test( prefix ) ) {
-		jQuery.cssHooks[ prefix + suffix ].set = setPositiveNumber;
-	}
+    if ( !rmargin.test( prefix ) ) {
+        jQuery.cssHooks[ prefix + suffix ].set = setPositiveNumber;
+    }
 });
 var r20 = /%20/g,
-	rbracket = /\[\]$/,
-	rCRLF = /\r?\n/g,
-	rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
-	rsubmittable = /^(?:input|select|textarea|keygen)/i;
+    rbracket = /\[\]$/,
+    rCRLF = /\r?\n/g,
+    rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
+    rsubmittable = /^(?:input|select|textarea|keygen)/i;
 
 jQuery.fn.extend({
-	serialize: function() {
-		return jQuery.param( this.serializeArray() );
-	},
-	serializeArray: function() {
-		return this.map(function(){
-			// Can add propHook for "elements" to filter or add form elements
-			var elements = jQuery.prop( this, "elements" );
-			return elements ? jQuery.makeArray( elements ) : this;
-		})
-		.filter(function(){
-			var type = this.type;
-			// Use .is(":disabled") so that fieldset[disabled] works
-			return this.name && !jQuery( this ).is( ":disabled" ) &&
-				rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
-				( this.checked || !manipulation_rcheckableType.test( type ) );
-		})
-		.map(function( i, elem ){
-			var val = jQuery( this ).val();
+    serialize: function() {
+        return jQuery.param( this.serializeArray() );
+    },
+    serializeArray: function() {
+        return this.map(function(){
+            // Can add propHook for "elements" to filter or add form elements
+            var elements = jQuery.prop( this, "elements" );
+            return elements ? jQuery.makeArray( elements ) : this;
+        })
+        .filter(function(){
+            var type = this.type;
+            // Use .is(":disabled") so that fieldset[disabled] works
+            return this.name && !jQuery( this ).is( ":disabled" ) &&
+                rsubmittable.test( this.nodeName ) && !rsubmitterTypes.test( type ) &&
+                ( this.checked || !manipulation_rcheckableType.test( type ) );
+        })
+        .map(function( i, elem ){
+            var val = jQuery( this ).val();
 
-			return val == null ?
-				null :
-				jQuery.isArray( val ) ?
-					jQuery.map( val, function( val ){
-						return { name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
-					}) :
-					{ name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
-		}).get();
-	}
+            return val == null ?
+                null :
+                jQuery.isArray( val ) ?
+                    jQuery.map( val, function( val ){
+                        return { name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
+                    }) :
+                    { name: elem.name, value: val.replace( rCRLF, "\r\n" ) };
+        }).get();
+    }
 });
 
 //Serialize an array of form elements or a set of
 //key/values into a query string
 jQuery.param = function( a, traditional ) {
-	var prefix,
-		s = [],
-		add = function( key, value ) {
-			// If value is a function, invoke it and return its value
-			value = jQuery.isFunction( value ) ? value() : ( value == null ? "" : value );
-			s[ s.length ] = encodeURIComponent( key ) + "=" + encodeURIComponent( value );
-		};
+    var prefix,
+        s = [],
+        add = function( key, value ) {
+            // If value is a function, invoke it and return its value
+            value = jQuery.isFunction( value ) ? value() : ( value == null ? "" : value );
+            s[ s.length ] = encodeURIComponent( key ) + "=" + encodeURIComponent( value );
+        };
 
-	// Set traditional to true for jQuery <= 1.3.2 behavior.
-	if ( traditional === undefined ) {
-		traditional = jQuery.ajaxSettings && jQuery.ajaxSettings.traditional;
-	}
+    // Set traditional to true for jQuery <= 1.3.2 behavior.
+    if ( traditional === undefined ) {
+        traditional = jQuery.ajaxSettings && jQuery.ajaxSettings.traditional;
+    }
 
-	// If an array was passed in, assume that it is an array of form elements.
-	if ( jQuery.isArray( a ) || ( a.jquery && !jQuery.isPlainObject( a ) ) ) {
-		// Serialize the form elements
-		jQuery.each( a, function() {
-			add( this.name, this.value );
-		});
+    // If an array was passed in, assume that it is an array of form elements.
+    if ( jQuery.isArray( a ) || ( a.jquery && !jQuery.isPlainObject( a ) ) ) {
+        // Serialize the form elements
+        jQuery.each( a, function() {
+            add( this.name, this.value );
+        });
 
-	} else {
-		// If traditional, encode the "old" way (the way 1.3.2 or older
-		// did it), otherwise encode params recursively.
-		for ( prefix in a ) {
-			buildParams( prefix, a[ prefix ], traditional, add );
-		}
-	}
+    } else {
+        // If traditional, encode the "old" way (the way 1.3.2 or older
+        // did it), otherwise encode params recursively.
+        for ( prefix in a ) {
+            buildParams( prefix, a[ prefix ], traditional, add );
+        }
+    }
 
-	// Return the resulting serialization
-	return s.join( "&" ).replace( r20, "+" );
+    // Return the resulting serialization
+    return s.join( "&" ).replace( r20, "+" );
 };
 
 function buildParams( prefix, obj, traditional, add ) {
-	var name;
+    var name;
 
-	if ( jQuery.isArray( obj ) ) {
-		// Serialize array item.
-		jQuery.each( obj, function( i, v ) {
-			if ( traditional || rbracket.test( prefix ) ) {
-				// Treat each array item as a scalar.
-				add( prefix, v );
+    if ( jQuery.isArray( obj ) ) {
+        // Serialize array item.
+        jQuery.each( obj, function( i, v ) {
+            if ( traditional || rbracket.test( prefix ) ) {
+                // Treat each array item as a scalar.
+                add( prefix, v );
 
-			} else {
-				// Item is non-scalar (array or object), encode its numeric index.
-				buildParams( prefix + "[" + ( typeof v === "object" ? i : "" ) + "]", v, traditional, add );
-			}
-		});
+            } else {
+                // Item is non-scalar (array or object), encode its numeric index.
+                buildParams( prefix + "[" + ( typeof v === "object" ? i : "" ) + "]", v, traditional, add );
+            }
+        });
 
-	} else if ( !traditional && jQuery.type( obj ) === "object" ) {
-		// Serialize object item.
-		for ( name in obj ) {
-			buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );
-		}
+    } else if ( !traditional && jQuery.type( obj ) === "object" ) {
+        // Serialize object item.
+        for ( name in obj ) {
+            buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );
+        }
 
-	} else {
-		// Serialize scalar item.
-		add( prefix, obj );
-	}
+    } else {
+        // Serialize scalar item.
+        add( prefix, obj );
+    }
+}
+jQuery.fn.offset = function( options ) {
+    if ( arguments.length ) {
+        return options === undefined ?
+            this :
+            this.each(function( i ) {
+                jQuery.offset.setOffset( this, options, i );
+            });
+    }
+
+    var docElem, win,
+        elem = this[ 0 ],
+        box = { top: 0, left: 0 },
+        doc = elem && elem.ownerDocument;
+
+    if ( !doc ) {
+        return;
+    }
+
+    docElem = doc.documentElement;
+
+    // Make sure it's not a disconnected DOM node
+    if ( !jQuery.contains( docElem, elem ) ) {
+        return box;
+    }
+
+    // If we don't have gBCR, just use 0,0 rather than error
+    // BlackBerry 5, iOS 3 (original iPhone)
+    if ( typeof elem.getBoundingClientRect !== core_strundefined ) {
+        box = elem.getBoundingClientRect();
+    }
+    win = getWindow( doc );
+    return {
+        top: box.top + win.pageYOffset - docElem.clientTop,
+        left: box.left + win.pageXOffset - docElem.clientLeft
+    };
+};
+
+jQuery.offset = {
+
+    setOffset: function( elem, options, i ) {
+        var curPosition, curLeft, curCSSTop, curTop, curOffset, curCSSLeft, calculatePosition,
+            position = jQuery.css( elem, "position" ),
+            curElem = jQuery( elem ),
+            props = {};
+
+        // Set position first, in-case top/left are set even on static elem
+        if ( position === "static" ) {
+            elem.style.position = "relative";
+        }
+
+        curOffset = curElem.offset();
+        curCSSTop = jQuery.css( elem, "top" );
+        curCSSLeft = jQuery.css( elem, "left" );
+        calculatePosition = ( position === "absolute" || position === "fixed" ) && ( curCSSTop + curCSSLeft ).indexOf("auto") > -1;
+
+        // Need to be able to calculate position if either top or left is auto and position is either absolute or fixed
+        if ( calculatePosition ) {
+            curPosition = curElem.position();
+            curTop = curPosition.top;
+            curLeft = curPosition.left;
+
+        } else {
+            curTop = parseFloat( curCSSTop ) || 0;
+            curLeft = parseFloat( curCSSLeft ) || 0;
+        }
+
+        if ( jQuery.isFunction( options ) ) {
+            options = options.call( elem, i, curOffset );
+        }
+
+        if ( options.top != null ) {
+            props.top = ( options.top - curOffset.top ) + curTop;
+        }
+        if ( options.left != null ) {
+            props.left = ( options.left - curOffset.left ) + curLeft;
+        }
+
+        if ( "using" in options ) {
+            options.using.call( elem, props );
+
+        } else {
+            curElem.css( props );
+        }
+    }
+};
+
+
+jQuery.fn.extend({
+
+    position: function() {
+        if ( !this[ 0 ] ) {
+            return;
+        }
+
+        var offsetParent, offset,
+            elem = this[ 0 ],
+            parentOffset = { top: 0, left: 0 };
+
+        // Fixed elements are offset from window (parentOffset = {top:0, left: 0}, because it is it's only offset parent
+        if ( jQuery.css( elem, "position" ) === "fixed" ) {
+            // We assume that getBoundingClientRect is available when computed position is fixed
+            offset = elem.getBoundingClientRect();
+
+        } else {
+            // Get *real* offsetParent
+            offsetParent = this.offsetParent();
+
+            // Get correct offsets
+            offset = this.offset();
+            if ( !jQuery.nodeName( offsetParent[ 0 ], "html" ) ) {
+                parentOffset = offsetParent.offset();
+            }
+
+            // Add offsetParent borders
+            parentOffset.top += jQuery.css( offsetParent[ 0 ], "borderTopWidth", true );
+            parentOffset.left += jQuery.css( offsetParent[ 0 ], "borderLeftWidth", true );
+        }
+
+        // Subtract parent offsets and element margins
+        return {
+            top: offset.top - parentOffset.top - jQuery.css( elem, "marginTop", true ),
+            left: offset.left - parentOffset.left - jQuery.css( elem, "marginLeft", true )
+        };
+    },
+
+    offsetParent: function() {
+        return this.map(function() {
+            var offsetParent = this.offsetParent || docElem;
+
+            while ( offsetParent && ( !jQuery.nodeName( offsetParent, "html" ) && jQuery.css( offsetParent, "position") === "static" ) ) {
+                offsetParent = offsetParent.offsetParent;
+            }
+
+            return offsetParent || docElem;
+        });
+    }
+});
+
+
+// Create scrollLeft and scrollTop methods
+jQuery.each( {scrollLeft: "pageXOffset", scrollTop: "pageYOffset"}, function( method, prop ) {
+    var top = "pageYOffset" === prop;
+
+    jQuery.fn[ method ] = function( val ) {
+        return jQuery.access( this, function( elem, method, val ) {
+            var win = getWindow( elem );
+
+            if ( val === undefined ) {
+                return win ? win[ prop ] : elem[ method ];
+            }
+
+            if ( win ) {
+                win.scrollTo(
+                    !top ? val : window.pageXOffset,
+                    top ? val : window.pageYOffset
+                );
+
+            } else {
+                elem[ method ] = val;
+            }
+        }, method, val, arguments.length, null );
+    };
+});
+
+function getWindow( elem ) {
+    return jQuery.isWindow( elem ) ? elem : elem.nodeType === 9 && elem.defaultView;
 }
 // Create innerHeight, innerWidth, height, width, outerHeight and outerWidth methods
 jQuery.each( { Height: "height", Width: "width" }, function( name, type ) {
-	jQuery.each( { padding: "inner" + name, content: type, "": "outer" + name }, function( defaultExtra, funcName ) {
-		// margin is only for outerHeight, outerWidth
-		jQuery.fn[ funcName ] = function( margin, value ) {
-			var chainable = arguments.length && ( defaultExtra || typeof margin !== "boolean" ),
-				extra = defaultExtra || ( margin === true || value === true ? "margin" : "border" );
+    jQuery.each( { padding: "inner" + name, content: type, "": "outer" + name }, function( defaultExtra, funcName ) {
+        // margin is only for outerHeight, outerWidth
+        jQuery.fn[ funcName ] = function( margin, value ) {
+            var chainable = arguments.length && ( defaultExtra || typeof margin !== "boolean" ),
+                extra = defaultExtra || ( margin === true || value === true ? "margin" : "border" );
 
-			return jQuery.access( this, function( elem, type, value ) {
-				var doc;
+            return jQuery.access( this, function( elem, type, value ) {
+                var doc;
 
-				if ( jQuery.isWindow( elem ) ) {
-					// As of 5/8/2012 this will yield incorrect results for Mobile Safari, but there
-					// isn't a whole lot we can do. See pull request at this URL for discussion:
-					// https://github.com/jquery/jquery/pull/764
-					return elem.document.documentElement[ "client" + name ];
-				}
+                if ( jQuery.isWindow( elem ) ) {
+                    // As of 5/8/2012 this will yield incorrect results for Mobile Safari, but there
+                    // isn't a whole lot we can do. See pull request at this URL for discussion:
+                    // https://github.com/jquery/jquery/pull/764
+                    return elem.document.documentElement[ "client" + name ];
+                }
 
-				// Get document width or height
-				if ( elem.nodeType === 9 ) {
-					doc = elem.documentElement;
+                // Get document width or height
+                if ( elem.nodeType === 9 ) {
+                    doc = elem.documentElement;
 
-					// Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height],
-					// whichever is greatest
-					return Math.max(
-						elem.body[ "scroll" + name ], doc[ "scroll" + name ],
-						elem.body[ "offset" + name ], doc[ "offset" + name ],
-						doc[ "client" + name ]
-					);
-				}
+                    // Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height],
+                    // whichever is greatest
+                    return Math.max(
+                        elem.body[ "scroll" + name ], doc[ "scroll" + name ],
+                        elem.body[ "offset" + name ], doc[ "offset" + name ],
+                        doc[ "client" + name ]
+                    );
+                }
 
-				return value === undefined ?
-					// Get width or height on the element, requesting but not forcing parseFloat
-					jQuery.css( elem, type, extra ) :
+                return value === undefined ?
+                    // Get width or height on the element, requesting but not forcing parseFloat
+                    jQuery.css( elem, type, extra ) :
 
-					// Set width or height on the element
-					jQuery.style( elem, type, value, extra );
-			}, type, chainable ? margin : undefined, chainable, null );
-		};
-	});
+                    // Set width or height on the element
+                    jQuery.style( elem, type, value, extra );
+            }, type, chainable ? margin : undefined, chainable, null );
+        };
+    });
 });
 if ( typeof module === "object" && module && typeof module.exports === "object" ) {
-	// Expose jQuery as module.exports in loaders that implement the Node
-	// module pattern (including browserify). Do not create the global, since
-	// the user will be storing it themselves locally, and globals are frowned
-	// upon in the Node module world.
-	module.exports = jQuery;
+    // Expose jQuery as module.exports in loaders that implement the Node
+    // module pattern (including browserify). Do not create the global, since
+    // the user will be storing it themselves locally, and globals are frowned
+    // upon in the Node module world.
+    module.exports = jQuery;
 } else {
-	// Register as a named AMD module, since jQuery can be concatenated with other
-	// files that may use define, but not via a proper concatenation script that
-	// understands anonymous AMD modules. A named AMD is safest and most robust
-	// way to register. Lowercase jquery is used because AMD module names are
-	// derived from file names, and jQuery is normally delivered in a lowercase
-	// file name. Do this after creating the global so that if an AMD module wants
-	// to call noConflict to hide this version of jQuery, it will work.
-	if ( typeof define === "function" && define.amd ) {
-		define( "jquery", [], function () { return jQuery; } );
-	}
+    // Register as a named AMD module, since jQuery can be concatenated with other
+    // files that may use define, but not via a proper concatenation script that
+    // understands anonymous AMD modules. A named AMD is safest and most robust
+    // way to register. Lowercase jquery is used because AMD module names are
+    // derived from file names, and jQuery is normally delivered in a lowercase
+    // file name. Do this after creating the global so that if an AMD module wants
+    // to call noConflict to hide this version of jQuery, it will work.
+    if ( typeof define === "function" && define.amd ) {
+        define( "jquery", [], function () { return jQuery; } );
+    }
 }
 
 // If there is a window object, that at least has a document property,
 // define jQuery and $ identifiers
 if ( typeof window === "object" && typeof window.document === "object" ) {
-	window.jQuery = window.$ = jQuery;
+    window.jQuery = window.$ = jQuery;
 }
 
 })( window );


### PR DESCRIPTION
Not sure why it was removed, perhaps all of the checkboxes were just unchecked in jquery builder. Offset is pretty standard, and it could have been useful back when I was doing the image deferrer. After trying to use a drag and drop library for transonic that needed offset, maybe let's add it back to all of commonplace.

I used https://raw.githubusercontent.com/jgallen23/jquery-builder/0.5.0/dist/2.0.2/jquery-ajax-deprecated-effects-event-alias-sizzle.js
