### PR TITLE
allow objects with arrays to be sent as json in requests

### DIFF
--- a/src/media/js/commonplace/requests.js
+++ b/src/media/js/commonplace/requests.js
@@ -14,13 +14,13 @@ define('requests',
         }
     }
 
-    function _is_obj(obj) {
-        return obj && obj.constructor === Object;
+    function _is_obj_or_array(obj) {
+        return obj && obj.constructor === Object || Array.isArray(obj);
     }
 
     function _has_object_props(obj) {
         for (var i in obj) {
-            if (obj.hasOwnProperty(i) && _is_obj(obj[i])) {
+            if (obj.hasOwnProperty(i) && _is_obj_or_array(obj[i])) {
                 return true;
             }
         }
@@ -68,7 +68,7 @@ define('requests',
 
         var content_type = 'application/x-www-form-urlencoded';
         if (data) {
-            if (_is_obj(data) && !_has_object_props(data)) {
+            if (_is_obj_or_array(data) && !_has_object_props(data)) {
                 data = utils.urlencode(data);
             } else if (!(data instanceof RawData)) {
                 data = JSON.stringify(data);


### PR DESCRIPTION
Had a data structure that looked like:

`{'restofworld': ['app', 32]}` and requests didn't like it.

This fixes, but I am not sure it is correct.
