### PR TITLE
Create symlinks instead of hard links

### DIFF
--- a/lib/commonplace.js
+++ b/lib/commonplace.js
@@ -786,7 +786,7 @@ function fiddle() {
             var sym_destination = path.resolve(process.cwd(), symlink);
             // Don't create link if it already exists.
             if (fs.existsSync(sym_destination)) continue;
-            fs.linkSync(path.resolve(projects_target, name, sym_path), sym_destination);
+            fs.symlinkSync(path.resolve(projects_target, name, sym_path), sym_destination);
         }
         callback();
     }


### PR DESCRIPTION
When installing zamboni, commonplace tries to create a hard link from one directory to another, which, well, doesn't work. Creating symlinks instead worked for me.
