### PR TITLE
Handle the marketplace-core-modules core/ prefix

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,54 +1,6 @@
-var CORE_MODULES = [
-    // Core JS modules.
-    // Will tell Gulp which modules to pull into marketplace-core-modules/.
-    // Will tell the require.js config which files live in marketplace-core-modules/.
-    'assert',
-    'buckets',
-    'builder',
-    'cache',
-    'capabilities',
-    'defer',
-    'forms',
-    'format',
-    'helpers',
-    'l10n',
-    'log',
-    'login',
-    'models',
-    'navigation',
-    'notification',
-    'nunjucks',
-    'nunjucks.compat',
-    'polyfill',
-    'requests',
-    'scroll_state',
-    'site_config',
-    'storage',
-    'urls',
-    'user',
-    'utils',
-    'views',
-    'z'
-];
-
-var CORE_MODULES_ROOT_JS = [
-    // Core modules that traditionally live in the root JS path.
-    'l10n',
-    'views'
-];
-
-var CORE_VIEWS = [
-    'views/fxa_authorize',
-    'views/not_found',
-    'views/tests'
-];
-
 var BASE_PATH = 'src/media/';
-var CORE_SRC_PATH = 'marketplace-core-modules/';
-var CORE_TEMPLATE_PATH = 'commonplace/dist/core-templates/';
 var JS_DEST_PATH = BASE_PATH + 'js/';
 var LIB_DEST_PATH = JS_DEST_PATH + 'lib/';
-var CORE_DEST_PATH = LIB_DEST_PATH + 'marketplace-core-modules/';
 var CSS_DEST_PATH = BASE_PATH + 'css/';
 
 // Build config object to tell Gulp which Bower files into project and where.
@@ -58,31 +10,17 @@ var bowerConfig = {
     // TODO: Use the official nunjucks and not a modified one.
     // 'nunjucks/browser/nunjucks-slim.js': LIB_DEST_PATH,
     'underscore/underscore.js': LIB_DEST_PATH,
-    'marketplace-core-modules/tests/**/*.js': CORE_DEST_PATH + 'tests',
-    'marketplace-core-modules/tests/tests.html': 'src/templates/commonplace/'
 };
-CORE_MODULES.forEach(function(module) {
-    if (CORE_MODULES_ROOT_JS.indexOf(module) !== -1) {
-        // Modules that go into the root JS path (for some reason).
-        bowerConfig[CORE_SRC_PATH + module + '.js'] = JS_DEST_PATH;
-        return;
-    }
-    bowerConfig[CORE_SRC_PATH + module + '.js'] = CORE_DEST_PATH;
-});
-CORE_VIEWS.forEach(function(view) {
-    bowerConfig[CORE_SRC_PATH + view + '.js'] = CORE_DEST_PATH + 'views/';
-});
 
 // Build require config, to be used in development and AMD optimizers.
 var requireConfig = {
     enforceDefine: true,
     paths: {
+        'core': 'lib/core',
         'jquery': 'lib/jquery',
         // 'nunjucks': 'lib/nunjucks-slim',
         'templates': '../../templates',
         'underscore': 'lib/underscore',
-        'views/not_found': 'lib/marketplace-core-modules/views/not_found',
-        'views/tests': 'lib/marketplace-core-modules/views/tests',
     },
     shim: {
         'underscore': {
@@ -90,15 +28,6 @@ var requireConfig = {
         },
     }
 };
-CORE_MODULES.forEach(function(module) {
-    if (CORE_MODULES_ROOT_JS.indexOf(module) !== -1) {
-        return;
-    }
-    requireConfig.paths[module] = 'lib/marketplace-core-modules/' + module;
-});
-CORE_VIEWS.forEach(function(view) {
-    requireConfig.paths[view] = 'lib/marketplace-core-modules/' + view;
-});
 
 var BOWER_PATH = process.env.BOWER_PATH || './bower_components/';
 


### PR DESCRIPTION
DO NOT MERGE! This depends on the m-c-m module renaming and marketplace-gulp webserver updates in the v2.0.0/testing updates.

Stop copying marketplace-core-modules files because the webserver will now serve them.